### PR TITLE
Support generic requirements

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -65,7 +65,9 @@ public extension MockableGenerator {
             outputType: outputType,
             effectType: effectType,
             parameterNames: parameterNames,
-            parameterLabels: parameterLabels
+            parameterLabels: parameterLabels,
+            genericParameterClause: funcDecl.genericParameterClause,
+            genericWhereClause: funcDecl.genericWhereClause
         )
 
         return DeclSyntax(stubFunction)
@@ -150,20 +152,32 @@ public extension MockableGenerator {
     /// For example, for a function `doSomething(with value: String) -> Int`, this will generate:
     /// ```swift
     /// func doSomething(with value: ArgMatcher<String>) -> Interaction<String, None, Int> {
-    ///     Interaction(value, spy: doSomething)
+    ///     Interaction(value, spy: super.doSomething)
     /// }
     /// ```
-    private static func createStubFunction(name: String, spyPropertyName: String, inputTypes: [TypeSyntax], outputType: TypeSyntax, effectType: String, parameterNames: [TokenSyntax], parameterLabels: [TokenSyntax?]) throws -> FunctionDeclSyntax {
+    private static func createStubFunction(
+        name: String,
+        spyPropertyName: String,
+        inputTypes: [TypeSyntax],
+        outputType: TypeSyntax,
+        effectType: String,
+        parameterNames: [TokenSyntax],
+        parameterLabels: [TokenSyntax?],
+        genericParameterClause: GenericParameterClauseSyntax?,
+        genericWhereClause: GenericWhereClauseSyntax?
+    ) throws -> FunctionDeclSyntax {
         let parameterList = createParameterList(inputTypes: inputTypes, parameterNames: parameterNames, parameterLabels: parameterLabels)
         let returnType = createInteractionReturnType(inputTypes: inputTypes, outputType: outputType, effectType: effectType)
         let body = createFunctionBody(spyPropertyName: spyPropertyName, parameterNames: parameterNames)
 
         return FunctionDeclSyntax(
             name: TokenSyntax.identifier(name),
+            genericParameterClause: genericParameterClause,
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax { parameterList },
                 returnClause: returnType
             ),
+            genericWhereClause: genericWhereClause,
             body: body
         )
     }

--- a/Sources/MockableTypes/ArgMatcher.swift
+++ b/Sources/MockableTypes/ArgMatcher.swift
@@ -61,6 +61,19 @@ public struct ArgMatcher<Argument> {
     public static func any(that predicate: @escaping (Argument) -> Bool) -> Self {
         return .init(matcher: predicate)
     }
+
+    /// A matcher that matches an argument if it can be cast to a specific type.
+    ///
+    /// This is useful when dealing with protocols or superclasses, and you want to match a specific concrete type.
+    /// For example casting an argument of type: `any CustomStringConvertible` to  `String`.
+    ///
+    /// - Parameter type: The type to check for casting.
+    /// - Returns: An `ArgMatcher` that matches if the argument can be cast to the given type.
+    public static func `as`<T>(_ type: T.Type) -> Self {
+        .init(matcher: { argument in
+            (argument as? T) != nil
+        })
+    }
 }
 
 public extension ArgMatcher where Argument: Equatable {

--- a/Sources/MockableTypes/ArgMatcher.swift
+++ b/Sources/MockableTypes/ArgMatcher.swift
@@ -27,7 +27,11 @@
 /// ```
 public struct ArgMatcher<Argument> {
     let matcher: (Argument) -> Bool
-    
+
+    public init(matcher: @escaping (Argument) -> Bool) {
+        self.matcher = matcher
+    }
+
     /// Calls the underlying matcher function with the given value.
     /// - Parameter value: The argument value to match against.
     /// - Returns: `true` if the value matches, `false` otherwise.

--- a/Tests/MockableMacroTests/FunctionSignatureTests.swift
+++ b/Tests/MockableMacroTests/FunctionSignatureTests.swift
@@ -276,4 +276,36 @@ final class FunctionSignatureTests: XCTestCase {
             """
         }
     }
+
+    func testGenericParameter() {
+        assertMacro {
+            """
+            @Mockable
+            public protocol AnalyticsProtocol: Sendable {
+                func logEvent<E: Identifiable>(_ event: E) -> Bool
+            }
+            """
+        } expansion: {
+            """
+            public protocol AnalyticsProtocol: Sendable {
+                func logEvent<E: Identifiable>(_ event: E) -> Bool
+            }
+
+            class AnalyticsProtocolMock: Mock {
+                typealias Witness = AnalyticsProtocolWitness<AnalyticsProtocolMock>
+                var instance: Witness.Synthesized {
+                    .init(
+                        context: self,
+                        witness: .init(
+                            logEvent: adaptNone(self, super.logEvent)
+                        )
+                    )
+                }
+                func logEvent<E: Identifiable>(_ event: ArgMatcher<E>) -> Interaction<E, None, Bool> {
+                    Interaction(event, spy: super.logEvent)
+                }
+            }
+            """
+        }
+    }
 }

--- a/Tests/MockableMacroTests/FunctionSignatureTests.swift
+++ b/Tests/MockableMacroTests/FunctionSignatureTests.swift
@@ -301,7 +301,7 @@ final class FunctionSignatureTests: XCTestCase {
                         )
                     )
                 }
-                func logEvent<E: Identifiable>(_ event: ArgMatcher<E>) -> Interaction<E, None, Bool> {
+                func logEvent(_ event: ArgMatcher<any Identifiable>) -> Interaction<any Identifiable, None, Bool> {
                     Interaction(event, spy: super.logEvent)
                 }
             }

--- a/Tests/MockableTests/MockTests.swift
+++ b/Tests/MockableTests/MockTests.swift
@@ -10,6 +10,20 @@ final class MockTests: XCTestCase {
         XCTAssertEqual(mock.spies.count, 1)
     }
 
+    func testSubscript_WhenSpyIsGeneric() {
+        let mock = Mock()
+        func createSpy<E: CustomStringConvertible>(type: E.Type, mock: Mock) -> Spy<E, None, String> {
+            return mock.mySpy
+
+        }
+        let spy = createSpy(type: Int.self, mock: mock)
+        let spy2 = createSpy(type: Int.self, mock: mock)
+
+        XCTAssert(spy === spy2)
+        XCTAssert(spy as? Spy<any CustomStringConvertible, None, String> != nil)
+        XCTAssertEqual(mock.spies.count, 1)
+    }
+
     func testSubscript_WhenSpyExists_ReturnsExistingSpy() {
         let mock = Mock()
         let spy1: Spy<Int, None, Void> = mock.myFunction

--- a/Tests/MockableTests/MockTests.swift
+++ b/Tests/MockableTests/MockTests.swift
@@ -20,7 +20,6 @@ final class MockTests: XCTestCase {
         let spy2 = createSpy(type: Int.self, mock: mock)
 
         XCTAssert(spy === spy2)
-        XCTAssert(spy as? Spy<any CustomStringConvertible, None, String> != nil)
         XCTAssertEqual(mock.spies.count, 1)
     }
 


### PR DESCRIPTION
Generic constraints are mapped to `any Constraint` since closures have the limitation of not being able to have a generic clause.