### PR TITLE
Update generated code to use witness lookup

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/DanielCardonaRojas/swift-witness",
       "state" : {
         "branch" : "main",
-        "revision" : "7f6afa3d7b3e05157daece2e1633933a01de34ec"
+        "revision" : "ff2c486752a4b4613286aaf4840ad2192bb3a1d8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,9 @@ let package = Package(
             dependencies: [
                 "MockableMacro",
             ]),
-        .target(name: "MockableTypes"),
+        .target(name: "MockableTypes", dependencies: [
+            .product(name: "WitnessTypes", package: "swift-witness"),
+        ]),
         .target(
             name: "MockableGenerator",
             dependencies: [

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -31,6 +31,11 @@ extension MockableGenerator {
                 colon: .colonToken(trailingTrivia: .space),
                 expression: contextArgument
             )
+            LabeledExprSyntax(
+                label: "strategy",
+                colon: .colonToken(trailingTrivia: .space),
+                expression: ExprSyntax(literal: "mocking")
+            )
         }
 
         let outerInit = FunctionCallExprSyntax(

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -101,21 +101,32 @@ extension MockableGenerator {
                 let funcName = funcDecl.name.text
                 let spyPropertyName = spyPropertyName(for: funcDecl, functionNames: &functionNames)
                 let effectType = getFunctionEffectType(funcDecl)
+                let isStatic = funcDecl.modifiers.contains(where: { $0.isStatic })
 
                 let adaptCall = FunctionCallExprSyntax(
                     callee: DeclReferenceExprSyntax(baseName: .identifier("adapt\(effectType)"))
                 ) {
-                    if !funcDecl.modifiers.contains(where: { $0.isStatic }) {
+                    if !isStatic {
                         LabeledExprSyntax(
                             expression: DeclReferenceExprSyntax(baseName: .identifier("self"))
                         )
                     }
-                    LabeledExprSyntax(
-                        expression: MemberAccessExprSyntax(
-                            base: SuperExprSyntax(),
-                            name: .identifier(spyPropertyName)
+                    if !isStatic {
+                        LabeledExprSyntax(
+                            expression: MemberAccessExprSyntax(
+                                base: SuperExprSyntax(),
+                                name: .identifier(spyPropertyName)
+                            )
                         )
-                    )
+                    } else {
+                        LabeledExprSyntax(
+                            expression: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: .identifier("Super")),
+                                name: .identifier(spyPropertyName)
+                            )
+                        )
+
+                    }
                 }
 
                 LabeledExprSyntax(

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -62,15 +62,6 @@ extension MockableGenerator {
         return DeclSyntax(instanceVar)
     }
 
-    static func makeStaticWitnessProperty(protocolDecl: ProtocolDeclSyntax) -> DeclSyntax {
-        let instanceVar = makeWitnessVar(
-            protocolDecl: protocolDecl,
-            modifiers: .init(arrayLiteral: .init(name: .keyword(.static)))
-        )
-
-        return DeclSyntax(instanceVar)
-    }
-
     private static func makeWitnessVar(protocolDecl: ProtocolDeclSyntax, modifiers: DeclModifierListSyntax = []) -> VariableDeclSyntax {
         let returnType = IdentifierTypeSyntax(name: .identifier("Witness"))
         return VariableDeclSyntax(

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -42,7 +42,7 @@ extension MockableGenerator {
 
         let getterBody = CodeBlockSyntax(
             statements: [
-                CodeBlockItemSyntax(item: .expr(ExprSyntax(outerInit)))
+                CodeBlockItemSyntax(item: .stmt(StmtSyntax(ReturnStmtSyntax(expression: ExprSyntax(outerInit))))),
             ]
         )
 

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -40,20 +40,16 @@ extension MockableGenerator {
             rightParen: .rightParenToken()
         )
 
-        let getterBody = CodeBlockSyntax(
-            statements: [
-                CodeBlockItemSyntax(stringLiteral: "witness.register(strategy: \"mocking\")"),
-                CodeBlockItemSyntax(item: .stmt(StmtSyntax(ReturnStmtSyntax(expression: ExprSyntax(outerInit))))),
-            ]
-        )
-
         let instanceVar = VariableDeclSyntax(
+            modifiers: .init([
+                DeclModifierSyntax(name: .keyword(.lazy))
+            ]),
             bindingSpecifier: .keyword(.var),
             bindings: [
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: .identifier("instance")),
                     typeAnnotation: TypeAnnotationSyntax(type: returnType),
-                    accessorBlock: AccessorBlockSyntax(accessors: .getter(getterBody.statements))
+                    initializer: .init(value: ExprSyntax(outerInit))
                 )
             ]
         )

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -66,9 +66,10 @@ extension MockableGenerator {
         return DeclSyntax(instanceVar)
     }
 
-    static func makeWitnessProperty(protocolDecl: ProtocolDeclSyntax) -> DeclSyntax {
+    static func makeWitnessProperty(protocolDecl: ProtocolDeclSyntax, modifiers: DeclModifierListSyntax = []) -> DeclSyntax {
         let returnType = IdentifierTypeSyntax(name: .identifier("Witness"))
         let instanceVar = VariableDeclSyntax(
+            modifiers: modifiers,
             bindingSpecifier: .keyword(.var),
             bindings: [
                 PatternBindingSyntax(

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -17,12 +17,7 @@ extension MockableGenerator {
     /// - Parameter protocolDecl: The `ProtocolDeclSyntax` to generate the property for.
     /// - Returns: A `DeclSyntax` representing the computed `instance` property.
     static func makeInstanceComputedProperty(protocolDecl: ProtocolDeclSyntax) -> DeclSyntax {
-        let mockWitnessTypeName = "Witness"
-
-        let returnType = MemberTypeSyntax(
-            baseType: IdentifierTypeSyntax(name: .identifier(mockWitnessTypeName)),
-            name: .identifier("Synthesized")
-        )
+        let returnType = IdentifierTypeSyntax(name: .identifier("Conformance"))
         let contextArgument = DeclReferenceExprSyntax(baseName: .keyword(.`self`))
 
         let outerInitArguments = LabeledExprListSyntax {

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -61,9 +61,23 @@ extension MockableGenerator {
         return DeclSyntax(instanceVar)
     }
 
-    static func makeWitnessProperty(protocolDecl: ProtocolDeclSyntax, modifiers: DeclModifierListSyntax = []) -> DeclSyntax {
+    static func makeWitnessProperty(protocolDecl: ProtocolDeclSyntax) -> DeclSyntax {
+        let instanceVar = makeWitnessVar(protocolDecl: protocolDecl)
+        return DeclSyntax(instanceVar)
+    }
+
+    static func makeStaticWitnessProperty(protocolDecl: ProtocolDeclSyntax) -> DeclSyntax {
+        let instanceVar = makeWitnessVar(
+            protocolDecl: protocolDecl,
+            modifiers: .init(arrayLiteral: .init(name: .keyword(.static)))
+        )
+
+        return DeclSyntax(instanceVar)
+    }
+
+    private static func makeWitnessVar(protocolDecl: ProtocolDeclSyntax, modifiers: DeclModifierListSyntax = []) -> VariableDeclSyntax {
         let returnType = IdentifierTypeSyntax(name: .identifier("Witness"))
-        let instanceVar = VariableDeclSyntax(
+        return VariableDeclSyntax(
             modifiers: modifiers,
             bindingSpecifier: .keyword(.var),
             bindings: [
@@ -76,7 +90,6 @@ extension MockableGenerator {
                 )
             ]
         )
-        return DeclSyntax(instanceVar)
     }
 
 
@@ -112,7 +125,9 @@ extension MockableGenerator {
             }
         }
         return FunctionCallExprSyntax(
-            calledExpression: MemberAccessExprSyntax(name: .keyword(.`init`)),
+            calledExpression: MemberAccessExprSyntax(
+                name: .keyword(.`init`)
+            ),
             leftParen: .leftParenToken(),
             arguments: witnessArguments,
             rightParen: .rightParenToken(leadingTrivia: .newline)

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -105,9 +105,11 @@ extension MockableGenerator {
                 let adaptCall = FunctionCallExprSyntax(
                     callee: DeclReferenceExprSyntax(baseName: .identifier("adapt\(effectType)"))
                 ) {
-                    LabeledExprSyntax(
-                        expression: DeclReferenceExprSyntax(baseName: .identifier("self"))
-                    )
+                    if !funcDecl.modifiers.contains(where: { $0.isStatic }) {
+                        LabeledExprSyntax(
+                            expression: DeclReferenceExprSyntax(baseName: .identifier("self"))
+                        )
+                    }
                     LabeledExprSyntax(
                         expression: MemberAccessExprSyntax(
                             base: SuperExprSyntax(),

--- a/Sources/MockableGenerator/MockableGenerator+Conformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Conformance.swift
@@ -47,6 +47,7 @@ extension MockableGenerator {
 
         let getterBody = CodeBlockSyntax(
             statements: [
+                CodeBlockItemSyntax(stringLiteral: "witness.register(strategy: \"mocking\")"),
                 CodeBlockItemSyntax(item: .stmt(StmtSyntax(ReturnStmtSyntax(expression: ExprSyntax(outerInit))))),
             ]
         )

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -54,18 +54,10 @@ public extension MockableGenerator {
         let funcName = funcDecl.name.text
         let spyPropertyName = MockableGenerator.spyPropertyName(for: funcDecl, functionNames: &functionNames)
 
-        let (inputTypes, parameterNames, parameterLabels) = getFunctionParameters(funcDecl)
-        let outputType = getFunctionReturnType(funcDecl)
-        let effectType = getFunctionEffectType(funcDecl)
-
         let stubFunction = try createStubFunction(
             name: funcName,
             spyPropertyName: spyPropertyName,
-            inputTypes: inputTypes,
-            outputType: outputType,
-            effectType: effectType,
-            parameterNames: parameterNames,
-            parameterLabels: parameterLabels,
+            funcDecl: funcDecl,
             genericParameterClause: funcDecl.genericParameterClause,
             genericWhereClause: funcDecl.genericWhereClause
         )
@@ -158,19 +150,21 @@ public extension MockableGenerator {
     private static func createStubFunction(
         name: String,
         spyPropertyName: String,
-        inputTypes: [TypeSyntax],
-        outputType: TypeSyntax,
-        effectType: String,
-        parameterNames: [TokenSyntax],
-        parameterLabels: [TokenSyntax?],
+        funcDecl: FunctionDeclSyntax,
         genericParameterClause: GenericParameterClauseSyntax?,
         genericWhereClause: GenericWhereClauseSyntax?
     ) throws -> FunctionDeclSyntax {
+
+        let (inputTypes, parameterNames, parameterLabels) = getFunctionParameters(funcDecl)
+        let outputType = getFunctionReturnType(funcDecl)
+        let effectType = getFunctionEffectType(funcDecl)
+
         let parameterList = createParameterList(inputTypes: inputTypes, parameterNames: parameterNames, parameterLabels: parameterLabels, genericParameterClause: genericParameterClause)
         let returnType = createInteractionReturnType(inputTypes: inputTypes, outputType: outputType, effectType: effectType, genericParameterClause: genericParameterClause)
         let body = createFunctionBody(spyPropertyName: spyPropertyName, parameterNames: parameterNames)
 
         return FunctionDeclSyntax(
+            modifiers: funcDecl.modifiers.trimmed,
             name: TokenSyntax.identifier(name),
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax { parameterList },

--- a/Sources/MockableGenerator/MockableGenerator+Typealias.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Typealias.swift
@@ -2,6 +2,33 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension MockableGenerator {
+    static func makeConformanceTypealias(protocolName: String, mockName: String) -> DeclSyntax {
+        let witnessTypeName = protocolName + "Witness"
+        let typealiasName = "Conformance"
+
+        let typealiasDecl = TypeAliasDeclSyntax(
+            name: .identifier(typealiasName),
+            initializer: TypeInitializerClauseSyntax(
+                value: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(
+                        name: .identifier(witnessTypeName),
+                        genericArgumentClause: GenericArgumentClauseSyntax(
+                            arguments: GenericArgumentListSyntax(
+                                [
+                                    GenericArgumentSyntax(
+                                        argument: IdentifierTypeSyntax(name: .identifier(mockName))
+                                    )
+                                ]
+                            )
+                        )
+                    ),
+                    name: .identifier("Synthesized")
+                )
+            )
+        )
+
+        return DeclSyntax(typealiasDecl)
+    }
     static func makeTypealiasDecl(protocolName: String, mockName: String) -> DeclSyntax {
         let witnessTypeName = protocolName + "Witness"
         let typealiasName = "Witness"

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -71,6 +71,7 @@ inheritedTypes: [
                 var members = [MemberBlockItemSyntax]()
                 members.append(MemberBlockItemSyntax(decl: typealiasDecl))
                 members.append(MemberBlockItemSyntax(decl: conformanceTypealiasDecl))
+                members.append(MemberBlockItemSyntax(decl: initializer()))
                 members.append(MemberBlockItemSyntax(decl: instanceProperty))
                 members.append(MemberBlockItemSyntax(decl: witnessProperty))
                 members.append(contentsOf: spyMembers.map { MemberBlockItemSyntax(decl: $0) })
@@ -122,5 +123,32 @@ inheritedTypes: [
         functionNames[funcName] = count + 1
         let baseName = count > 0 ? "\(funcName)_\(count)" : funcName
         return baseName
+    }
+
+    static func initializer() -> InitializerDeclSyntax {
+        InitializerDeclSyntax(
+            attributes: AttributeListSyntax([
+//                AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("discardableResult")))
+            ]),
+            modifiers: [
+                DeclModifierSyntax(name: .identifier("required")),
+                DeclModifierSyntax(name: .identifier("override"))
+            ],
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax(
+                    parameters: []
+                )
+            ),
+            body: CodeBlockSyntax(
+                statementsBuilder: {
+                CodeBlockItemSyntax(
+                    item: .init(
+                    DeclSyntax(stringLiteral: "super.init()")
+                ))
+                CodeBlockItemSyntax(item: .init(
+                    ExprSyntax(stringLiteral: "self.setup()")
+                ))
+            })
+        )
     }
 }

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -143,8 +143,17 @@ inheritedTypes: [
                 statementsBuilder: {
                 CodeBlockItemSyntax(
                     item: .init(
-                    DeclSyntax(stringLiteral: "super.init()")
-                ))
+                        ExprSyntax(
+                            FunctionCallExprSyntax(
+                                callee: ExprSyntax(
+                                    DeclReferenceExprSyntax(
+                                        baseName: .identifier("super.init")
+                                    )
+                                )
+                            )
+                        )
+                )
+)
                 CodeBlockItemSyntax(item: .init(
                     ExprSyntax(stringLiteral: "self.setup()")
                 ))

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -54,11 +54,19 @@ public enum MockableGenerator {
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
             name: TokenSyntax.identifier(mockName),
-            inheritanceClause: InheritanceClauseSyntax(inheritedTypes: [
+            inheritanceClause: InheritanceClauseSyntax(
+inheritedTypes: [
                 InheritedTypeSyntax(
-                    type: IdentifierTypeSyntax(name: .identifier("Mock"))
+                    type: IdentifierTypeSyntax(
+                        name: .identifier("Mock")
+                    ),
+                    trailingComma: .commaToken()
+                ),
+                InheritedTypeSyntax(
+                    type: IdentifierTypeSyntax(name: .identifier("MockWitnessContainer"))
                 )
-            ]),
+            ]
+),
             memberBlock: MemberBlockSyntax {
                 var members = [MemberBlockItemSyntax]()
                 members.append(MemberBlockItemSyntax(decl: typealiasDecl))

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -46,6 +46,7 @@ public enum MockableGenerator {
         let spyMembers = try makeInteractions(protocolDecl: protocolDecl)
         let typealiasDecl = makeTypealiasDecl(protocolName: protocolName, mockName: mockName)
         let instanceProperty = makeInstanceComputedProperty(protocolDecl: protocolDecl)
+        let witnessProperty = makeWitnessProperty(protocolDecl: protocolDecl)
 
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
@@ -59,6 +60,7 @@ public enum MockableGenerator {
                 var members = [MemberBlockItemSyntax]()
                 members.append(MemberBlockItemSyntax(decl: typealiasDecl))
                 members.append(MemberBlockItemSyntax(decl: instanceProperty))
+                members.append(MemberBlockItemSyntax(decl: witnessProperty))
                 members.append(contentsOf: spyMembers.map { MemberBlockItemSyntax(decl: $0) })
                 return MemberBlockItemListSyntax(members)
             }

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -50,7 +50,6 @@ public enum MockableGenerator {
         let conformanceTypealiasDecl = makeConformanceTypealias(protocolName: protocolName, mockName: mockName)
         let instanceProperty = makeInstanceComputedProperty(protocolDecl: protocolDecl)
         let witnessProperty = makeWitnessProperty(protocolDecl: protocolDecl)
-        let staticWitnessProperty = makeStaticWitnessProperty(protocolDecl: protocolDecl)
 
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
@@ -66,9 +65,6 @@ public enum MockableGenerator {
                 members.append(MemberBlockItemSyntax(decl: conformanceTypealiasDecl))
                 members.append(MemberBlockItemSyntax(decl: instanceProperty))
                 members.append(MemberBlockItemSyntax(decl: witnessProperty))
-                if hasStaticRequirements {
-                    members.append(MemberBlockItemSyntax(decl: staticWitnessProperty))
-                }
                 members.append(contentsOf: spyMembers.map { MemberBlockItemSyntax(decl: $0) })
                 return MemberBlockItemListSyntax(members)
             }

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -45,6 +45,7 @@ public enum MockableGenerator {
         // Generate the spy properties and methods using SpyGenerator
         let spyMembers = try makeInteractions(protocolDecl: protocolDecl)
         let typealiasDecl = makeTypealiasDecl(protocolName: protocolName, mockName: mockName)
+        let conformanceTypealiasDecl = makeConformanceTypealias(protocolName: protocolName, mockName: mockName)
         let instanceProperty = makeInstanceComputedProperty(protocolDecl: protocolDecl)
         let witnessProperty = makeWitnessProperty(protocolDecl: protocolDecl)
         let staticWitnessProperty = makeWitnessProperty(
@@ -63,6 +64,7 @@ public enum MockableGenerator {
             memberBlock: MemberBlockSyntax {
                 var members = [MemberBlockItemSyntax]()
                 members.append(MemberBlockItemSyntax(decl: typealiasDecl))
+                members.append(MemberBlockItemSyntax(decl: conformanceTypealiasDecl))
                 members.append(MemberBlockItemSyntax(decl: instanceProperty))
                 members.append(MemberBlockItemSyntax(decl: witnessProperty))
                 members.append(MemberBlockItemSyntax(decl: staticWitnessProperty))

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -47,6 +47,10 @@ public enum MockableGenerator {
         let typealiasDecl = makeTypealiasDecl(protocolName: protocolName, mockName: mockName)
         let instanceProperty = makeInstanceComputedProperty(protocolDecl: protocolDecl)
         let witnessProperty = makeWitnessProperty(protocolDecl: protocolDecl)
+        let staticWitnessProperty = makeWitnessProperty(
+            protocolDecl: protocolDecl,
+            modifiers: .init(arrayLiteral: .init(name: .keyword(.static)))
+        )
 
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
@@ -61,6 +65,7 @@ public enum MockableGenerator {
                 members.append(MemberBlockItemSyntax(decl: typealiasDecl))
                 members.append(MemberBlockItemSyntax(decl: instanceProperty))
                 members.append(MemberBlockItemSyntax(decl: witnessProperty))
+                members.append(MemberBlockItemSyntax(decl: staticWitnessProperty))
                 members.append(contentsOf: spyMembers.map { MemberBlockItemSyntax(decl: $0) })
                 return MemberBlockItemListSyntax(members)
             }

--- a/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
+++ b/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
@@ -1,0 +1,13 @@
+//
+//  SwiftSyntax+Extensions.swift
+//  swift-mocking
+//
+//  Created by Daniel Cardona on 17/07/25.
+//
+import SwiftSyntax
+
+extension DeclModifierSyntax {
+    var isStatic: Bool {
+        name.tokenKind == .keyword(.static)
+    }
+}

--- a/Sources/MockableTypes/Mock.swift
+++ b/Sources/MockableTypes/Mock.swift
@@ -16,7 +16,7 @@
 ///
 @dynamicMemberLookup
 open class Mock: DefaultProvider {
-    public static var this: Mock.Type {
+    public var Super: Mock.Type {
         Self.self as Mock.Type
     }
     public var defaultProviderRegistry: DefaultProvidableRegistry = .shared

--- a/Sources/MockableTypes/Mock.swift
+++ b/Sources/MockableTypes/Mock.swift
@@ -19,6 +19,11 @@ open class Mock: DefaultProvider {
     public var defaultProviderRegistry: DefaultProvidableRegistry = .shared
     public init() { }
     private(set) var spies: [String: AnySpy] = [:]
+    static private var spies_: [String: [String: AnySpy]] = [:]
+
+    static var spies: [String: AnySpy] {
+        spies_["\(Self.self)"] ?? [:]
+    }
 
     /// Provides a ``Spy`` instance for the given member name.
     ///
@@ -35,6 +40,21 @@ open class Mock: DefaultProvider {
         } else {
             let spy = Spy<repeat each Input, Eff, Output>()
             spies[member] = spy
+            return spy
+        }
+    }
+
+    public static subscript<each Input, Eff: Effect, Output>(dynamicMember member: String) -> Spy<repeat each Input, Eff, Output> {
+        let thisType = "\(Self.self)" // The name of the subclass mock
+        if spies_[thisType] == nil {
+            spies_[thisType] = [:]
+        }
+
+        if let existingSpy = spies_[thisType]?[member] as? Spy<repeat each Input, Eff, Output> {
+            return existingSpy
+        } else {
+            let spy = Spy<repeat each Input, Eff, Output>()
+            spies_[thisType]?[member] = spy
             return spy
         }
     }

--- a/Sources/MockableTypes/Mock.swift
+++ b/Sources/MockableTypes/Mock.swift
@@ -19,10 +19,12 @@ open class Mock: DefaultProvider {
     public var Super: Mock.Type {
         Self.self as Mock.Type
     }
+
     public var defaultProviderRegistry: DefaultProvidableRegistry = .shared
-    public init() { }
     private(set) var spies: [String: AnySpy] = [:]
     static private var spies_: [String: [String: AnySpy]] = [:]
+
+    public init() { }
 
     static var spies: [String: AnySpy] {
         spies_["\(Self.self)"] ?? [:]

--- a/Sources/MockableTypes/Mock.swift
+++ b/Sources/MockableTypes/Mock.swift
@@ -16,6 +16,9 @@
 ///
 @dynamicMemberLookup
 open class Mock: DefaultProvider {
+    public static var this: Mock.Type {
+        Self.self as Mock.Type
+    }
     public var defaultProviderRegistry: DefaultProvidableRegistry = .shared
     public init() { }
     private(set) var spies: [String: AnySpy] = [:]

--- a/Sources/MockableTypes/MockWitnessContainer.swift
+++ b/Sources/MockableTypes/MockWitnessContainer.swift
@@ -1,0 +1,24 @@
+//
+//  MockWitnessContainer.swift
+//  swift-mocking
+//
+//  Created by Daniel Cardona on 17/07/25.
+//
+
+import WitnessTypes
+
+public protocol MockWitnessContainer<Witness> {
+    associatedtype Witness: RecordableMixin
+    var witness: Witness { get }
+    init()
+}
+
+public extension MockWitnessContainer {
+    func setup() {
+        witness.register(strategy: "mocking")
+        witness.register(strategy: "static")
+    }
+    static func setup() {
+        Self.init().setup()
+    }
+}

--- a/Sources/MockableTypes/SpyAdapters.swift
+++ b/Sources/MockableTypes/SpyAdapters.swift
@@ -5,46 +5,6 @@
 //  Created by Daniel Cardona on 13/07/25.
 //
 
-/// A helper that converts a spy into a closure that is easily assignable to a protocol witness closure property.
-public func adapt<Context: DefaultProvider, each I, O>(_ keyPath: KeyPath<Context, Spy<repeat each I, None, O>>) -> (Context, repeat each I) -> O {
-    { (context, input: repeat each I) -> O  in
-        let spy = context[keyPath: keyPath]
-        spy.defaultProviderRegistry = context.defaultProviderRegistry
-        let result = spy.call(repeat each input)
-        return result
-    }
-}
-
-/// A helper that converts a spy into a closure that is easily assignable to a protocol witness closure property.
-public func adapt<Context: DefaultProvider, each I, O>(_ keyPath: KeyPath<Context, Spy<repeat each I, Throws, O>>) -> (Context, repeat each I) throws -> O {
-    { (context, input: repeat each I) -> O  in
-        let spy = context[keyPath: keyPath]
-        spy.defaultProviderRegistry = context.defaultProviderRegistry
-        let result = try spy.call(repeat each input)
-        return result
-    }
-}
-
-/// A helper that converts an `async` spy into a closure that is easily assignable to a protocol witness closure property.
-public func adapt<Context: DefaultProvider, each I, O>(_ keyPath: KeyPath<Context, Spy<repeat each I, Async, O>>) -> (Context, repeat each I) async -> O {
-    { (context, input: repeat each I) async -> O  in
-        let spy = context[keyPath: keyPath]
-        spy.defaultProviderRegistry = context.defaultProviderRegistry
-        let result = await spy.call(repeat each input)
-        return result
-    }
-}
-
-/// A helper that converts an `async throws` spy into a closure that is easily assignable to a protocol witness closure property.
-public func adapt<Context: DefaultProvider, each I, O>(_ keyPath: KeyPath<Context, Spy<repeat each I, AsyncThrows, O>>) -> (Context, repeat each I) async throws -> O {
-    { (context, input: repeat each I) async throws -> O  in
-        let spy = context[keyPath: keyPath]
-        spy.defaultProviderRegistry = context.defaultProviderRegistry
-        let result = try await spy.call(repeat each input)
-        return result
-    }
-}
-
 // MARK: - Non Keypath variants
 
 /// A helper that converts a spy into a closure that is easily assignable to a protocol witness closure property.

--- a/Sources/MockableTypes/SpyAdapters.swift
+++ b/Sources/MockableTypes/SpyAdapters.swift
@@ -45,6 +45,8 @@ public func adapt<Context: DefaultProvider, each I, O>(_ keyPath: KeyPath<Contex
     }
 }
 
+// MARK: - Non Keypath variants
+
 /// A helper that converts a spy into a closure that is easily assignable to a protocol witness closure property.
 public func adaptNone<Context: DefaultProvider, each I, O>(_ context: Context, _ spy: Spy<repeat each I, None, O>) -> (Context, repeat each I) -> O {
     { (context, input: repeat each I) -> O  in
@@ -83,3 +85,36 @@ public func adaptAsyncThrows<Context: DefaultProvider, each I, O>(
     }
 }
 
+// MARK: Static variants
+
+/// A helper that converts a spy into a closure that is easily assignable to a protocol witness closure property.
+public func adaptNone<each I, O>(_ spy: Spy<repeat each I, None, O>) -> (repeat each I) -> O {
+    { (input: repeat each I) -> O  in
+        let result = spy.call(repeat each input)
+        return result
+    }
+}
+
+/// A helper that converts a spy into a closure that is easily assignable to a protocol witness closure property.
+public func adaptThrows<each I, O>(_ spy: Spy<repeat each I, Throws, O>) -> (repeat each I) throws -> O {
+    { (input: repeat each I) -> O  in
+        let result = try spy.call(repeat each input)
+        return result
+    }
+}
+
+/// A helper that converts an `async` spy into a closure that is easily assignable to a protocol witness closure property.
+public func adaptAsync<each I, O>(_ spy: Spy<repeat each I, Async, O>) -> (repeat each I) async -> O {
+    { (input: repeat each I) async -> O  in
+        let result = await spy.call(repeat each input)
+        return result
+    }
+}
+public func adaptAsyncThrows<each I, O>(
+    _ spy: Spy<repeat each I, AsyncThrows, O>
+) -> (repeat each I) async throws -> O {
+    { (input: repeat each I) async throws -> O  in
+        let result = try await spy.call(repeat each input)
+        return result
+    }
+}

--- a/Tests/MockableMacroTests/BasicTests.swift
+++ b/Tests/MockableMacroTests/BasicTests.swift
@@ -29,12 +29,13 @@ final class BasicTests: XCTestCase {
                 func price(_ item: String) -> Int
             }
 
-            class PricingServiceMock: Mock {
+            class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         price: adaptNone(self, super.price)

--- a/Tests/MockableMacroTests/BasicTests.swift
+++ b/Tests/MockableMacroTests/BasicTests.swift
@@ -5,16 +5,7 @@ import XCTest
 import MockableMacro
 import MacroTesting
 
-final class BasicTests: XCTestCase {
-    override func invokeTest() {
-      withMacroTesting(
-        record: false,
-        macros: ["Mockable": MockableMacro.self]
-      ) {
-        super.invokeTest()
-      }
-    }
-
+final class BasicTests: MacroTestCase {
     func testSingleMethodNoEffects() {
         assertMacro {
            """
@@ -32,7 +23,8 @@ final class BasicTests: XCTestCase {
             class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")

--- a/Tests/MockableMacroTests/BasicTests.swift
+++ b/Tests/MockableMacroTests/BasicTests.swift
@@ -32,11 +32,12 @@ final class BasicTests: XCTestCase {
             class PricingServiceMock: Mock {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            price: adaptNone(self, super.price)
-                        )
+                        price: adaptNone(self, super.price)
                     )
                 }
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {

--- a/Tests/MockableMacroTests/FunctionSignatureTests.swift
+++ b/Tests/MockableMacroTests/FunctionSignatureTests.swift
@@ -5,16 +5,7 @@ import XCTest
 import MockableMacro
 import MacroTesting
 
-final class FunctionSignatureTests: XCTestCase {
-    override func invokeTest() {
-      withMacroTesting(
-        record: false,
-        macros: ["Mockable": MockableMacro.self]
-      ) {
-        super.invokeTest()
-      }
-    }
-
+final class FunctionSignatureTests: MacroTestCase {
     func testSingleMethodNoEffects() {
         assertMacro {
            """
@@ -32,7 +23,8 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -66,7 +58,8 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -100,7 +93,8 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -134,7 +128,8 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -170,7 +165,8 @@ final class FunctionSignatureTests: XCTestCase {
             class FeedServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = FeedServiceWitness<FeedServiceMock>
                 typealias Conformance = FeedServiceWitness<FeedServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -208,7 +204,8 @@ final class FunctionSignatureTests: XCTestCase {
             class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
                 typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -242,7 +239,8 @@ final class FunctionSignatureTests: XCTestCase {
             class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
                 typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -276,7 +274,8 @@ final class FunctionSignatureTests: XCTestCase {
             class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
                 typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -311,7 +310,8 @@ final class FunctionSignatureTests: XCTestCase {
             class LoggerMock: Mock, MockWitnessContainer {
                 typealias Witness = LoggerWitness<LoggerMock>
                 typealias Conformance = LoggerWitness<LoggerMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -346,7 +346,8 @@ final class FunctionSignatureTests: XCTestCase {
             class AnalyticsProtocolMock: Mock, MockWitnessContainer {
                 typealias Witness = AnalyticsProtocolWitness<AnalyticsProtocolMock>
                 typealias Conformance = AnalyticsProtocolWitness<AnalyticsProtocolMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")

--- a/Tests/MockableMacroTests/FunctionSignatureTests.swift
+++ b/Tests/MockableMacroTests/FunctionSignatureTests.swift
@@ -29,12 +29,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func price(_ item: String) -> Int
             }
 
-            class PricingServiceMock: Mock {
+            class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         price: adaptNone(self, super.price)
@@ -62,12 +63,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func price(_ item: String) throws -> Int
             }
 
-            class PricingServiceMock: Mock {
+            class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         price: adaptThrows(self, super.price)
@@ -95,12 +97,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func price(_ item: String) async -> Int
             }
 
-            class PricingServiceMock: Mock {
+            class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         price: adaptAsync(self, super.price)
@@ -128,12 +131,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func price(_ item: String) async throws -> Int
             }
 
-            class PricingServiceMock: Mock {
+            class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         price: adaptAsyncThrows(self, super.price)
@@ -163,12 +167,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func post(to url: URL, data: Data) async throws
             }
 
-            class FeedServiceMock: Mock {
+            class FeedServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = FeedServiceWitness<FeedServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = FeedServiceWitness<FeedServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         fetch: adaptAsyncThrows(self, super.fetch),
@@ -200,12 +205,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func doSomething() -> String
             }
 
-            class ServiceMock: Mock {
+            class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         doSomething: adaptNone(self, super.doSomething)
@@ -233,12 +239,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func doSomething(with value: Int)
             }
 
-            class ServiceMock: Mock {
+            class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         doSomething: adaptNone(self, super.doSomething)
@@ -266,12 +273,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func doSomething()
             }
 
-            class ServiceMock: Mock {
+            class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         doSomething: adaptNone(self, super.doSomething)
@@ -283,6 +291,42 @@ final class FunctionSignatureTests: XCTestCase {
             }
             """
         }
+    }
+
+    func testStaticFunctionRequirement() {
+
+        assertMacro {
+            """
+            @Mockable
+            protocol Logger {
+                static func log(_ message: String)
+            }
+            """
+        } expansion: {
+            """
+            protocol Logger {
+                static func log(_ message: String)
+            }
+
+            class LoggerMock: Mock, MockWitnessContainer {
+                typealias Witness = LoggerWitness<LoggerMock>
+                typealias Conformance = LoggerWitness<LoggerMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
+                }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
+                var witness: Witness {
+                    .init(
+                        log: adaptNone(Super.log)
+                    )
+                }
+                static func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
+                    Interaction(message, spy: super.log)
+                }
+            }
+            """
+        }
+
     }
 
     func testGenericParameter() {
@@ -299,12 +343,13 @@ final class FunctionSignatureTests: XCTestCase {
                 func logEvent<E: Identifiable>(_ event: E) -> Bool
             }
 
-            class AnalyticsProtocolMock: Mock {
+            class AnalyticsProtocolMock: Mock, MockWitnessContainer {
                 typealias Witness = AnalyticsProtocolWitness<AnalyticsProtocolMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = AnalyticsProtocolWitness<AnalyticsProtocolMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         logEvent: adaptNone(self, super.logEvent)

--- a/Tests/MockableMacroTests/FunctionSignatureTests.swift
+++ b/Tests/MockableMacroTests/FunctionSignatureTests.swift
@@ -32,11 +32,12 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            price: adaptNone(self, super.price)
-                        )
+                        price: adaptNone(self, super.price)
                     )
                 }
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
@@ -64,11 +65,12 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            price: adaptThrows(self, super.price)
-                        )
+                        price: adaptThrows(self, super.price)
                     )
                 }
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Throws, Int> {
@@ -96,11 +98,12 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            price: adaptAsync(self, super.price)
-                        )
+                        price: adaptAsync(self, super.price)
                     )
                 }
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Async, Int> {
@@ -128,11 +131,12 @@ final class FunctionSignatureTests: XCTestCase {
             class PricingServiceMock: Mock {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            price: adaptAsyncThrows(self, super.price)
-                        )
+                        price: adaptAsyncThrows(self, super.price)
                     )
                 }
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, AsyncThrows, Int> {
@@ -162,12 +166,13 @@ final class FunctionSignatureTests: XCTestCase {
             class FeedServiceMock: Mock {
                 typealias Witness = FeedServiceWitness<FeedServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            fetch: adaptAsyncThrows(self, super.fetch),
-                            post: adaptAsyncThrows(self, super.post)
-                        )
+                        fetch: adaptAsyncThrows(self, super.fetch),
+                        post: adaptAsyncThrows(self, super.post)
                     )
                 }
                 func fetch(from url: ArgMatcher<URL>) -> Interaction<URL, AsyncThrows, Data> {
@@ -198,11 +203,12 @@ final class FunctionSignatureTests: XCTestCase {
             class ServiceMock: Mock {
                 typealias Witness = ServiceWitness<ServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            doSomething: adaptNone(self, super.doSomething)
-                        )
+                        doSomething: adaptNone(self, super.doSomething)
                     )
                 }
                 func doSomething() -> Interaction<None, String> {
@@ -230,11 +236,12 @@ final class FunctionSignatureTests: XCTestCase {
             class ServiceMock: Mock {
                 typealias Witness = ServiceWitness<ServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            doSomething: adaptNone(self, super.doSomething)
-                        )
+                        doSomething: adaptNone(self, super.doSomething)
                     )
                 }
                 func doSomething(with value: ArgMatcher<Int>) -> Interaction<Int, None, Void> {
@@ -262,11 +269,12 @@ final class FunctionSignatureTests: XCTestCase {
             class ServiceMock: Mock {
                 typealias Witness = ServiceWitness<ServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            doSomething: adaptNone(self, super.doSomething)
-                        )
+                        doSomething: adaptNone(self, super.doSomething)
                     )
                 }
                 func doSomething() -> Interaction<None, Void> {
@@ -294,11 +302,12 @@ final class FunctionSignatureTests: XCTestCase {
             class AnalyticsProtocolMock: Mock {
                 typealias Witness = AnalyticsProtocolWitness<AnalyticsProtocolMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            logEvent: adaptNone(self, super.logEvent)
-                        )
+                        logEvent: adaptNone(self, super.logEvent)
                     )
                 }
                 func logEvent(_ event: ArgMatcher<any Identifiable>) -> Interaction<any Identifiable, None, Bool> {

--- a/Tests/MockableMacroTests/MacroOptionsTests.swift
+++ b/Tests/MockableMacroTests/MacroOptionsTests.swift
@@ -29,12 +29,13 @@ final class MacroOptionsTests: XCTestCase {
                 func doSomething()
             }
 
-            class MockMyService: Mock {
+            class MockMyService: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MockMyService>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = MyServiceWitness<MockMyService>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         doSomething: adaptNone(self, super.doSomething)
@@ -62,12 +63,13 @@ final class MacroOptionsTests: XCTestCase {
                 func doSomething()
             }
 
-            class MyServiceMock: Mock {
+            class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         doSomething: adaptNone(self, super.doSomething)

--- a/Tests/MockableMacroTests/MacroOptionsTests.swift
+++ b/Tests/MockableMacroTests/MacroOptionsTests.swift
@@ -32,11 +32,12 @@ final class MacroOptionsTests: XCTestCase {
             class MockMyService: Mock {
                 typealias Witness = MyServiceWitness<MockMyService>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            doSomething: adaptNone(self, super.doSomething)
-                        )
+                        doSomething: adaptNone(self, super.doSomething)
                     )
                 }
                 func doSomething() -> Interaction<None, Void> {
@@ -64,11 +65,12 @@ final class MacroOptionsTests: XCTestCase {
             class MyServiceMock: Mock {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            doSomething: adaptNone(self, super.doSomething)
-                        )
+                        doSomething: adaptNone(self, super.doSomething)
                     )
                 }
                 func doSomething() -> Interaction<None, Void> {

--- a/Tests/MockableMacroTests/MacroOptionsTests.swift
+++ b/Tests/MockableMacroTests/MacroOptionsTests.swift
@@ -5,16 +5,7 @@ import XCTest
 import MockableMacro
 import MacroTesting
 
-final class MacroOptionsTests: XCTestCase {
-    override func invokeTest() {
-      withMacroTesting(
-        record: false,
-        macros: ["Mockable": MockableMacro.self]
-      ) {
-        super.invokeTest()
-      }
-    }
-
+final class MacroOptionsTests: MacroTestCase {
     func testPrefixMockOption() {
         assertMacro {
             """
@@ -32,7 +23,8 @@ final class MacroOptionsTests: XCTestCase {
             class MockMyService: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MockMyService>
                 typealias Conformance = MyServiceWitness<MockMyService>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -66,7 +58,8 @@ final class MacroOptionsTests: XCTestCase {
             class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")

--- a/Tests/MockableMacroTests/MacroTestCase.swift
+++ b/Tests/MockableMacroTests/MacroTestCase.swift
@@ -1,0 +1,22 @@
+//
+//  MacroTestCase.swift
+//  swift-mocking
+//
+//  Created by Daniel Cardona on 17/07/25.
+//
+import XCTest
+import MockableMacro
+import MacroTesting
+
+class  MacroTestCase: XCTestCase {
+    override func invokeTest() {
+      withMacroTesting(
+        record: false,
+        macros: ["Mockable": MockableMacro.self]
+      ) {
+        super.invokeTest()
+      }
+    }
+
+}
+

--- a/Tests/MockableMacroTests/MockableMacroTests.swift
+++ b/Tests/MockableMacroTests/MockableMacroTests.swift
@@ -10,16 +10,7 @@ import MacroTesting
 import MockableMacro
 import MockableTypes
 
-final class MockableMacroTests: XCTestCase {
-    override func invokeTest() {
-      withMacroTesting(
-        record: false,
-        macros: ["Mockable": MockableMacro.self]
-      ) {
-        super.invokeTest()
-      }
-    }
-
+final class MockableMacroTests: MacroTestCase {
     func testSingleMethodNoEffects() {
         assertMacro {
            """
@@ -37,7 +28,8 @@ final class MockableMacroTests: XCTestCase {
             class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")

--- a/Tests/MockableMacroTests/MockableMacroTests.swift
+++ b/Tests/MockableMacroTests/MockableMacroTests.swift
@@ -34,12 +34,13 @@ final class MockableMacroTests: XCTestCase {
                 func price(_ item: String) -> Int
             }
 
-            class PricingServiceMock: Mock {
+            class PricingServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = PricingServiceWitness<PricingServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         price: adaptNone(self, super.price)

--- a/Tests/MockableMacroTests/MockableMacroTests.swift
+++ b/Tests/MockableMacroTests/MockableMacroTests.swift
@@ -37,11 +37,12 @@ final class MockableMacroTests: XCTestCase {
             class PricingServiceMock: Mock {
                 typealias Witness = PricingServiceWitness<PricingServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            price: adaptNone(self, super.price)
-                        )
+                        price: adaptNone(self, super.price)
                     )
                 }
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {

--- a/Tests/MockableMacroTests/ProtocolFeaturesTests.swift
+++ b/Tests/MockableMacroTests/ProtocolFeaturesTests.swift
@@ -5,15 +5,7 @@ import XCTest
 import MockableMacro
 import MacroTesting
 
-final class ProtocolFeaturesTests: XCTestCase {
-    override func invokeTest() {
-      withMacroTesting(
-        record: false,
-        macros: ["Mockable": MockableMacro.self]
-      ) {
-        super.invokeTest()
-      }
-    }
+final class ProtocolFeaturesTests: MacroTestCase {
 
     func testPublicProtocol() {
         assertMacro {
@@ -32,7 +24,8 @@ final class ProtocolFeaturesTests: XCTestCase {
             class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
                 typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -66,7 +59,8 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -96,7 +90,8 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -126,7 +121,8 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")
@@ -158,7 +154,8 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
-                required override init() {super.init()
+                required override init() {
+                    super.init()
                     self.setup()
                 }
                 lazy var instance: Conformance = .init(context: self, strategy: "mocking")

--- a/Tests/MockableMacroTests/ProtocolFeaturesTests.swift
+++ b/Tests/MockableMacroTests/ProtocolFeaturesTests.swift
@@ -29,12 +29,13 @@ final class ProtocolFeaturesTests: XCTestCase {
                 func doSomething()
             }
 
-            class ServiceMock: Mock {
+            class ServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = ServiceWitness<ServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = ServiceWitness<ServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         doSomething: adaptNone(self, super.doSomething)
@@ -62,12 +63,13 @@ final class ProtocolFeaturesTests: XCTestCase {
                 var value: Int { get }
             }
 
-            class MyServiceMock: Mock {
+            class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                     )
@@ -91,12 +93,13 @@ final class ProtocolFeaturesTests: XCTestCase {
                 init(value: Int)
             }
 
-            class MyServiceMock: Mock {
+            class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                     )
@@ -120,12 +123,13 @@ final class ProtocolFeaturesTests: XCTestCase {
                 subscript(index: Int) -> String { get }
             }
 
-            class MyServiceMock: Mock {
+            class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                     )
@@ -151,12 +155,13 @@ final class ProtocolFeaturesTests: XCTestCase {
                 func item() -> Item
             }
 
-            class MyServiceMock: Mock {
+            class MyServiceMock: Mock, MockWitnessContainer {
                 typealias Witness = MyServiceWitness<MyServiceMock>
-                var instance: Witness.Synthesized {
-                    witness.register(strategy: "mocking")
-                    return .init(context: self, strategy: "mocking")
+                typealias Conformance = MyServiceWitness<MyServiceMock>.Synthesized
+                required override init() {super.init()
+                    self.setup()
                 }
+                lazy var instance: Conformance = .init(context: self, strategy: "mocking")
                 var witness: Witness {
                     .init(
                         item: adaptNone(self, super.item)

--- a/Tests/MockableMacroTests/ProtocolFeaturesTests.swift
+++ b/Tests/MockableMacroTests/ProtocolFeaturesTests.swift
@@ -32,11 +32,12 @@ final class ProtocolFeaturesTests: XCTestCase {
             class ServiceMock: Mock {
                 typealias Witness = ServiceWitness<ServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            doSomething: adaptNone(self, super.doSomething)
-                        )
+                        doSomething: adaptNone(self, super.doSomething)
                     )
                 }
                 func doSomething() -> Interaction<None, Void> {
@@ -64,10 +65,11 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                        )
                     )
                 }
             }
@@ -92,10 +94,11 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                        )
                     )
                 }
             }
@@ -120,10 +123,11 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                        )
                     )
                 }
             }
@@ -150,11 +154,12 @@ final class ProtocolFeaturesTests: XCTestCase {
             class MyServiceMock: Mock {
                 typealias Witness = MyServiceWitness<MyServiceMock>
                 var instance: Witness.Synthesized {
+                    witness.register(strategy: "mocking")
+                    return .init(context: self, strategy: "mocking")
+                }
+                var witness: Witness {
                     .init(
-                        context: self,
-                        witness: .init(
-                            item: adaptNone(self, super.item)
-                        )
+                        item: adaptNone(self, super.item)
                     )
                 }
                 func item() -> Interaction<None, Item> {

--- a/Tests/MockableTests/Examples.swift
+++ b/Tests/MockableTests/Examples.swift
@@ -2,6 +2,7 @@
 import Foundation
 import Mockable
 import MockableTypes
+import WitnessTypes
 
 // MARK: - Function Signature Variations
 

--- a/Tests/MockableTests/MockTests.swift
+++ b/Tests/MockableTests/MockTests.swift
@@ -61,4 +61,23 @@ final class MockTests: XCTestCase {
         XCTAssertEqual(spy1.stubs.count, 0)
         XCTAssertEqual(spy2.stubs.count, 0)
     }
+
+    func testStatic() {
+        class LoggerMock: Mock {
+            static func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
+                Interaction(message, spy: super.log)
+            }
+        }
+
+        class PrinterMock: Mock {
+            static func print(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
+                Interaction(message, spy: super.print)
+            }
+        }
+
+        _ = LoggerMock.log(.any)
+        _ = PrinterMock.print(.any)
+        XCTAssertEqual(LoggerMock.spies.values.count, 1)
+        XCTAssertEqual(PrinterMock.spies.values.count, 1)
+    }
 }

--- a/Tests/MockableTests/MockitoTests.swift
+++ b/Tests/MockableTests/MockitoTests.swift
@@ -8,6 +8,7 @@
 import Mockable
 import MockableTypes
 import XCTest
+import WitnessTypes
 
 final class MockitoTests: XCTestCase {
     func testMockitoBuilder() {
@@ -25,7 +26,7 @@ final class MockitoTests: XCTestCase {
 
     func test_default_provider() {
         let registry = DefaultProvidableRegistry([Int.self])
-        var mock = PricingServiceMock()
+        let mock = PricingServiceMock()
         mock.defaultProviderRegistry = registry
         let store = Store(pricingService: mock.instance)
         store.register("apple")
@@ -124,6 +125,14 @@ final class MockitoTests: XCTestCase {
         verify(mock.logEvent(.as(TestEvent.self))).called()
     }
 
+    func testStatic() {
+        LoggerMock.witness.register(strategy: "static")
+        when(LoggerMock.log(.any)).thenReturn(())
+        LoggerMock.Conformance.log("hello")
+        LoggerMock.Conformance.log("hello")
+        verify(LoggerMock.log("hello")).called(2)
+    }
+
 }
 
 class Store {
@@ -168,7 +177,11 @@ protocol Calculator {
 }
 
 @Mockable([.includeWitness])
-public protocol AnalyticsProtocol: Sendable {
+protocol AnalyticsProtocol {
     func logEvent<E: Identifiable>(_ event: E)
 }
 
+@Mockable([.includeWitness])
+protocol Logger {
+    static func log(_ message: String)
+}

--- a/Tests/MockableTests/MockitoTests.swift
+++ b/Tests/MockableTests/MockitoTests.swift
@@ -11,6 +11,10 @@ import XCTest
 import WitnessTypes
 
 final class MockitoTests: XCTestCase {
+    override class func setUp() {
+        LoggerMock.setup()
+    }
+
     func testMockitoBuilder() {
         let mock = PricingServiceMock()
         let store = Store(pricingService: mock.instance)
@@ -126,7 +130,6 @@ final class MockitoTests: XCTestCase {
     }
 
     func testStatic() {
-        LoggerMock.witness.register(strategy: "static")
         when(LoggerMock.log(.any)).thenReturn(())
         LoggerMock.Conformance.log("hello")
         LoggerMock.Conformance.log("hello")


### PR DESCRIPTION
Use the new table based mechanism from swift-witness. instance and witness properties are now independent.

- Add static subscript on mock so static methods are supported.
- Make instance property lazy
- Add setup methods