### PR TITLE
Add precedence rules for invocation matchers

### DIFF
--- a/Sources/SwiftMocking/InvocationMatcher.swift
+++ b/Sources/SwiftMocking/InvocationMatcher.swift
@@ -46,5 +46,13 @@ public struct InvocationMatcher<each I> {
         }
         return match(invocation: invocation, matchers: (repeat each matchers))
     }
+
+    public var precedence: Int {
+        var sum = 0
+        for matcher in repeat each matchers {
+            sum += matcher.precedence.value
+        }
+        return sum
+    }
 }
 

--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -59,7 +59,7 @@ public class Spy<each Input, Effects: Effect, Output>: AnySpy {
         // search through stub for a return value
         var matchingStub: Stub<repeat each Input, Effects, Output>?
 
-        for stub in stubs {
+        for stub in stubs.reversed().sorted(by: { $0.precedence > $1.precedence }) {
             if stub.invocationMatcher.isMatchedBy(Invocation(arguments: repeat each input)) {
                 matchingStub = stub
                 break

--- a/Sources/SwiftMocking/Stub.swift
+++ b/Sources/SwiftMocking/Stub.swift
@@ -40,7 +40,10 @@ public class Stub<each I, Effects: Effect, O> {
             let returnValue = handler(repeat each invocation.arguments)
             return Return.value(returnValue)
         }
+    }
 
+    public var precedence: MatcherPrecedence {
+        .init(value: invocationMatcher.precedence)
     }
 }
 


### PR DESCRIPTION
Adds precedence values so that order of stubbing does not usually matter.