### PR TITLE
Improve autocomplete in Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,10 @@ extension PricingServiceMock: PricingService {
         return try adaptThrowing(super.price, item)
     }
 }
+
 ```
+
+Xcode's autocomplete will prioritize methods in the order they are declared. Since mocks are usualy not interacted with directly we opt for declaring the Interaction methods first.
 
 ## 📜 License
 

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -66,8 +66,8 @@ public enum MockableGenerator {
             memberBlock: MemberBlockSyntax {
                 var members = [MemberBlockItemSyntax]()
                 members.append(contentsOf: typeAliases.map({ MemberBlockItemSyntax(decl: $0)}))
-                members.append(contentsOf: conformanceRequirements.map { MemberBlockItemSyntax(decl: $0) })
                 members.append(contentsOf: interactions.map { MemberBlockItemSyntax(decl: $0) })
+                members.append(contentsOf: conformanceRequirements.map { MemberBlockItemSyntax(decl: $0) })
                 return MemberBlockItemListSyntax(members)
             }
         )

--- a/Sources/SwiftMockingMacros/SwiftMockingMacro.swift
+++ b/Sources/SwiftMockingMacros/SwiftMockingMacro.swift
@@ -35,8 +35,6 @@ public enum MockableMacro: PeerMacro {
             throw MacroError(message: "@WitnessMacro only works on protocols declarations")
         }
 
-        let codeGenOptions = MockableGenerator.codeGenOptions(protocolDecl: protocolDecl)
-
         let mockableDecls = try MockableGenerator.processProtocol(protocolDecl: protocolDecl)
         var allDecls: [DeclSyntax] = []
 

--- a/Tests/SwiftMockingMacrosTests/BasicTests.swift
+++ b/Tests/SwiftMockingMacrosTests/BasicTests.swift
@@ -20,12 +20,12 @@ final class BasicTests: MacroTestCase {
             }
 
             #if DEBUG
-            class PricingServiceMock: Mock, PricingService {
-                func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
-                }
+            class MockPricingService: Mock, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) -> Int {
+                    return adapt(super.price, item)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
+++ b/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
@@ -20,12 +20,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class PricingServiceMock: Mock, PricingService {
-                func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
-                }
+            class MockPricingService: Mock, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) -> Int {
+                    return adapt(super.price, item)
                 }
             }
             #endif
@@ -48,12 +48,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class PricingServiceMock: Mock, PricingService {
-                func price(_ item: String) throws -> Int {
-                    return try adaptThrowing(super.price, item)
-                }
+            class MockPricingService: Mock, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Throws, Int> {
                     Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) throws -> Int {
+                    return try adaptThrowing(super.price, item)
                 }
             }
             #endif
@@ -76,12 +76,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class PricingServiceMock: Mock, PricingService {
-                func price(_ item: String) async -> Int {
-                    return await adapt(super.price, item)
-                }
+            class MockPricingService: Mock, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Async, Int> {
                     Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) async -> Int {
+                    return await adapt(super.price, item)
                 }
             }
             #endif
@@ -104,12 +104,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class PricingServiceMock: Mock, PricingService {
-                func price(_ item: String) async throws -> Int {
-                    return try await adaptThrowing(super.price, item)
-                }
+            class MockPricingService: Mock, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, AsyncThrows, Int> {
                     Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) async throws -> Int {
+                    return try await adaptThrowing(super.price, item)
                 }
             }
             #endif
@@ -134,18 +134,18 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class FeedServiceMock: Mock, FeedService {
-                func fetch(from url: URL) async throws -> Data {
-                    return try await adaptThrowing(super.fetch, url)
-                }
-                func post(to url: URL, data: Data) async throws {
-                    return try await adaptThrowing(super.post, url, data)
-                }
+            class MockFeedService: Mock, FeedService {
                 func fetch(from url: ArgMatcher<URL>) -> Interaction<URL, AsyncThrows, Data> {
                     Interaction(url, spy: super.fetch)
                 }
                 func post(to url: ArgMatcher<URL>, data: ArgMatcher<Data>) -> Interaction<URL, Data, AsyncThrows, Void> {
                     Interaction(url, data, spy: super.post)
+                }
+                func fetch(from url: URL) async throws -> Data {
+                    return try await adaptThrowing(super.fetch, url)
+                }
+                func post(to url: URL, data: Data) async throws {
+                    return try await adaptThrowing(super.post, url, data)
                 }
             }
             #endif
@@ -168,12 +168,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class ServiceMock: Mock, Service {
-                func doSomething() -> String {
-                    return adapt(super.doSomething)
-                }
+            class MockService: Mock, Service {
                 func doSomething() -> Interaction<Void, None, String> {
                     Interaction(.any, spy: super.doSomething)
+                }
+                func doSomething() -> String {
+                    return adapt(super.doSomething)
                 }
             }
             #endif
@@ -196,12 +196,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class ServiceMock: Mock, Service {
-                func doSomething(with value: Int) {
-                    return adapt(super.doSomething, value)
-                }
+            class MockService: Mock, Service {
                 func doSomething(with value: ArgMatcher<Int>) -> Interaction<Int, None, Void> {
                     Interaction(value, spy: super.doSomething)
+                }
+                func doSomething(with value: Int) {
+                    return adapt(super.doSomething, value)
                 }
             }
             #endif
@@ -224,12 +224,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class ServiceMock: Mock, Service {
-                func doSomething() {
-                    return adapt(super.doSomething)
-                }
+            class MockService: Mock, Service {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
+                }
+                func doSomething() {
+                    return adapt(super.doSomething)
                 }
             }
             #endif
@@ -253,12 +253,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class LoggerMock: Mock, Logger {
-                static func log(_ message: String) {
-                    return adapt(super.log, message)
-                }
+            class MockLogger: Mock, Logger {
                 static func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                     Interaction(message, spy: super.log)
+                }
+                    static func log(_ message: String) {
+                    return adapt(super.log, message)
                 }
             }
             #endif
@@ -282,12 +282,12 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class AnalyticsProtocolMock: Mock, AnalyticsProtocol {
-                func logEvent<E: Identifiable>(_ event: E) -> Bool {
-                    return adapt(super.logEvent, event)
-                }
+            class MockAnalyticsProtocol: Mock, AnalyticsProtocol {
                 func logEvent<E: Identifiable>(_ event: ArgMatcher<E>) -> Interaction<E, None, Bool> {
                     Interaction(event, spy: super.logEvent)
+                }
+                func logEvent<E: Identifiable>(_ event: E) -> Bool {
+                    return adapt(super.logEvent, event)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -21,11 +21,11 @@ final class MacroOptionsTests: MacroTestCase {
 
             #if DEBUG
             class MockMyService: Mock, MyService {
-                func doSomething() {
-                    return adapt(super.doSomething)
-                }
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
+                }
+                func doSomething() {
+                    return adapt(super.doSomething)
                 }
             }
             #endif
@@ -49,11 +49,11 @@ final class MacroOptionsTests: MacroTestCase {
 
             #if DEBUG
             class MyServiceMock: Mock, MyService {
-                func doSomething() {
-                    return adapt(super.doSomething)
-                }
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
+                }
+                func doSomething() {
+                    return adapt(super.doSomething)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
@@ -24,12 +24,12 @@ final class MockableMacroTests: MacroTestCase {
             }
 
             #if DEBUG
-            class PricingServiceMock: Mock, PricingService {
-                func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
-                }
+            class MockPricingService: Mock, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) -> Int {
+                    return adapt(super.price, item)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -21,12 +21,12 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class ServiceMock: Mock, Service {
-                func doSomething() {
-                    return adapt(super.doSomething)
-                }
+            class MockService: Mock, Service {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
+                }
+                func doSomething() {
+                    return adapt(super.doSomething)
                 }
             }
             #endif
@@ -49,15 +49,15 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MyServiceMock: Mock, MyService {
+            class MockMyService: Mock, MyService {
+                func getValue() -> Interaction<Void, None, Int > {
+                    Interaction(.any, spy: super.value)
+                }
 
-                var value: Int {
+                    var value: Int {
                     get {
                         adapt(super.value)
                     }
-                }
-                func getValue() -> Interaction<Void, None, Int > {
-                    Interaction(.any, spy: super.value)
                 }
             }
             #endif
@@ -80,7 +80,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MyServiceMock: Mock, MyService {
+            class MockMyService: Mock, MyService {
                 required init(value: Int) {
                 }
             }
@@ -104,15 +104,15 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MyServiceMock: Mock, MyService {
-                subscript(index: Int) -> String {
-                    get {
-                        return adapt(super.subscript, index)
-                    }
-                }
+            class MockMyService: Mock, MyService {
                 subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String > {
                     get {
                         Interaction(index, spy: super.subscript)
+                    }
+                }
+                subscript(index: Int) -> String {
+                    get {
+                        return adapt(super.subscript, index)
                     }
                 }
             }
@@ -138,13 +138,13 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MyServiceMock<Item>: Mock, MyService {
+            class MockMyService<Item>: Mock, MyService {
                 typealias Item = Item
-                func item() -> Item {
-                    return adapt(super.item)
-                }
                 func item() -> Interaction<Void, None, Item> {
                     Interaction(.any, spy: super.item)
+                }
+                func item() -> Item {
+                    return adapt(super.item)
                 }
             }
             #endif


### PR DESCRIPTION
Xcode will pickup which ever method is declared first. This PR swaps order of interaction methods with conformance methods so that interaction methods are prioritized.