### PR TITLE
Convert Spies to functions

### DIFF
--- a/Examples/Sources/Examples/MockedProtocols.swift
+++ b/Examples/Sources/Examples/MockedProtocols.swift
@@ -2,6 +2,10 @@ import Foundation
 import SwiftMocking
 
 
+struct FetchClient {
+    var loadNumber: () async throws -> [Int]
+    var saveNumber: (Int) async throws -> Void
+}
 
 // MARK: - Function Signature Variations
 

--- a/Examples/Tests/ExamplesTests/ExampleXCTests.swift
+++ b/Examples/Tests/ExamplesTests/ExampleXCTests.swift
@@ -256,8 +256,8 @@ final class MockitoTests: XCTestCase {
         when(loadNumberSpy(.any)).thenReturn([3])
 
         let client = FetchClient(
-            loadNumber: { try await loadNumberSpy.call(()) },
-            saveNumber: saveNumberSpy.asFunction()
+            loadNumber: adapt(loadNumberSpy),
+            saveNumber: adapt(saveNumberSpy)
         )
 
         _ = try await client.loadNumber()

--- a/Examples/Tests/ExamplesTests/ExampleXCTests.swift
+++ b/Examples/Tests/ExamplesTests/ExampleXCTests.swift
@@ -244,4 +244,27 @@ final class MockitoTests: XCTestCase {
         }
         verify(mock.delete(key: "deleteKey")).throws()
     }
+
+    func testClosureStruct() async throws {
+        let loadNumberSpy = Spy<Void, AsyncThrows, [Int]>()
+        let saveNumberSpy = Spy<Int, AsyncThrows, Void>()
+
+        when(saveNumberSpy(.any)).then {
+            print(">>> number: \($0)")
+        }
+
+        when(loadNumberSpy(.any)).thenReturn([3])
+
+        let client = FetchClient(
+            loadNumber: { try await loadNumberSpy.call(()) },
+            saveNumber: saveNumberSpy.asFunction()
+        )
+
+        _ = try await client.loadNumber()
+        _ = try await client.saveNumber(3)
+
+        verify(loadNumberSpy(.any)).called()
+        verify(saveNumberSpy(3)).called()
+
+    }
 }

--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -122,6 +122,11 @@ public class Spy<each Input, Effects: Effect, Output>: AnySpy {
         return stub
     }
 
+    /// Available so that spies can be used with `when` and `verify`.
+    public func callAsFunction(_ matchingInput: repeat ArgMatcher<each Input>) -> Interaction<repeat each Input, Effects, Output> {
+        Interaction(repeat each matchingInput, spy: self)
+    }
+
     /// Verifies that the spy's method was called at least once.
     /// - Parameter countMatcher: An optional ``ArgMatcher`` for `Int` to specify the expected call count. If `nil`, verifies at least one call.
     /// - Returns: `true` if the call count matches the criteria, `false` otherwise.

--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -228,6 +228,12 @@ extension Spy where Effects == Throws {
     public func call(_ input: repeat each Input) throws -> Output {
         try invoke(repeat each input).get()
     }
+
+    public func asFunction() -> (repeat each Input) throws -> Output {
+        return { (args:  repeat each Input) in
+            try self.call(repeat each args)
+        }
+    }
 }
 
 // MARK: None throwing
@@ -244,6 +250,12 @@ extension Spy where Effects == None {
             fatalError("MockingError: \(error.message)")
         } catch {
             fatalError("\(error.localizedDescription)")
+        }
+    }
+
+    public func asFunction() -> (repeat each Input) -> Output {
+        return { (args:  repeat each Input) in
+            self.call(repeat each args)
         }
     }
 }
@@ -264,6 +276,12 @@ extension Spy where Effects == Async {
             fatalError("\(error.localizedDescription)")
         }
     }
+
+    public func asFunction() -> (repeat each Input) async -> Output {
+        return { (args:  repeat each Input) in
+            await self.call(repeat each args)
+        }
+    }
 }
 
 // MARK: AsyncThrows
@@ -275,6 +293,12 @@ extension Spy where Effects == AsyncThrows {
     @discardableResult
     public func call(_ input: repeat each Input) async throws -> Output {
         try invoke(repeat each input).get()
+    }
+
+    public func asFunction() -> (repeat each Input) async throws -> Output {
+        return { (args:  repeat each Input) in
+            try await self.call(repeat each args)
+        }
     }
 }
 

--- a/Sources/SwiftMocking/SpyAdapters.swift
+++ b/Sources/SwiftMocking/SpyAdapters.swift
@@ -1,0 +1,42 @@
+//
+//  SpyAdapters.swift
+//  swift-mocking
+//
+//  Created by Daniel Cardona on 16/09/25.
+//
+
+
+// MARK: Void cases - Workaround for current parameter pack extension limitations
+public func adapt<Output>(_ spy: Spy<Void, Async, Output>) -> () async ->  Output {
+    { await spy.call(()) }
+}
+
+public func adapt<Output>(_ spy: Spy<Void, AsyncThrows, Output>) -> () async throws ->  Output {
+    { try await spy.call(()) }
+}
+
+public func adapt<Output>(_ spy: Spy<Void, Throws, Output>) -> () throws ->  Output {
+    { try spy.call(()) }
+}
+
+public func adapt<Output>(_ spy: Spy<Void, None, Output>) -> () ->  Output {
+    { spy.call(()) }
+}
+
+// MARK:  asFunction wrappers (to keep a consistent API)
+
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, Async, Output>) -> (repeat each Input) async ->  Output {
+    spy.asFunction()
+}
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, Throws, Output>) -> (repeat each Input) throws ->  Output {
+    spy.asFunction()
+}
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, AsyncThrows, Output>) -> (repeat each Input) async throws ->  Output {
+    spy.asFunction()
+}
+
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, None, Output>) -> (repeat each Input) ->  Output {
+    spy.asFunction()
+}
+
+


### PR DESCRIPTION
Improving ergonomics to test closure base dependencies. A common choice in TCA.