### PR TITLE
Make Spy adapters sendable

### DIFF
--- a/Sources/SwiftMocking/SpyAdapters.swift
+++ b/Sources/SwiftMocking/SpyAdapters.swift
@@ -7,35 +7,35 @@
 
 
 // MARK: Void cases - Workaround for current parameter pack extension limitations
-public func adapt<Output>(_ spy: Spy<Void, Async, Output>) -> () async ->  Output {
+public func adapt<Output>(_ spy: Spy<Void, Async, Output>) -> @Sendable () async ->  Output {
     { await spy.call(()) }
 }
 
-public func adapt<Output>(_ spy: Spy<Void, AsyncThrows, Output>) -> () async throws ->  Output {
+public func adapt<Output>(_ spy: Spy<Void, AsyncThrows, Output>) -> @Sendable () async throws ->  Output {
     { try await spy.call(()) }
 }
 
-public func adapt<Output>(_ spy: Spy<Void, Throws, Output>) -> () throws ->  Output {
+public func adapt<Output>(_ spy: Spy<Void, Throws, Output>) -> @Sendable () throws ->  Output {
     { try spy.call(()) }
 }
 
-public func adapt<Output>(_ spy: Spy<Void, None, Output>) -> () ->  Output {
+public func adapt<Output>(_ spy: Spy<Void, None, Output>) -> @Sendable () ->  Output {
     { spy.call(()) }
 }
 
 // MARK:  asFunction wrappers (to keep a consistent API)
 
-public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, Async, Output>) -> (repeat each Input) async ->  Output {
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, Async, Output>) -> @Sendable (repeat each Input) async ->  Output {
     spy.asFunction()
 }
-public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, Throws, Output>) -> (repeat each Input) throws ->  Output {
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, Throws, Output>) -> @Sendable (repeat each Input) throws ->  Output {
     spy.asFunction()
 }
-public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, AsyncThrows, Output>) -> (repeat each Input) async throws ->  Output {
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, AsyncThrows, Output>) -> @Sendable (repeat each Input) async throws ->  Output {
     spy.asFunction()
 }
 
-public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, None, Output>) -> (repeat each Input) ->  Output {
+public func adapt<each Input, Output>(_ spy: Spy<repeat each Input, None, Output>) -> @Sendable (repeat each Input) ->  Output {
     spy.asFunction()
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Returned closures from spy adapters are now Sendable, enabling safe use across tasks and actors and improved compatibility with Swift Concurrency.

* **Refactor**
  * Updated type annotations to add Sendable without changing runtime behavior.

* **Notes**
  * This may require minor source updates if your code relied on non-Sendable closure types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->