### PR TITLE
Set default registry on spies

### DIFF
--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -29,7 +29,7 @@ public class Spy<each Input, Effects: Effect, Output>: AnySpy {
 
     private(set) var stubs: [Stub<repeat each Input, Effects, Output>] = []
     private(set) var actions: [Action<repeat each Input, Effects>] = []
-    var defaultProviderRegistry: DefaultProvidableRegistry?
+    var defaultProviderRegistry: DefaultProvidableRegistry? = .default
     var logger: ((Invocation<repeat each Input>) -> Void)?
     var invocationCount: Int {
         invocations.count

--- a/Tests/SwiftMockingTests/AssertTests.swift
+++ b/Tests/SwiftMockingTests/AssertTests.swift
@@ -9,7 +9,6 @@ final class AssertTests: XCTestCase {
     override func setUp() {
         super.setUp()
         spy = Spy()
-        spy.when(calledWith: .any).thenReturn(())
     }
 
     func testAssertCalled() throws {
@@ -56,7 +55,6 @@ final class AssertTests: XCTestCase {
 
     func testDoesThrowFailsWhenNoErrorThrown() {
         let throwingSpy = Spy<String, Throws, Void>()
-        throwingSpy.when(calledWith: .any).thenReturn(())
         _ = try? throwingSpy.call("test")
 
         let assert = Assert(spy: throwingSpy)
@@ -187,7 +185,6 @@ final class AssertTests: XCTestCase {
     
     func testCapturedWithMultipleArguments() throws {
         let multiArgSpy = Spy<String, Int, None, Void>()
-        multiArgSpy.when(calledWith: .any, .any).thenReturn(())
         
         multiArgSpy.call("first", 1)
         multiArgSpy.call("second", 2)

--- a/Tests/SwiftMockingTests/SpyTests.swift
+++ b/Tests/SwiftMockingTests/SpyTests.swift
@@ -203,7 +203,6 @@ final class SpyTests: XCTestCase {
         let spy = Spy<String, None, Void>()
         var captured: [String] = []
 
-        when(spy(.any)).thenReturn(())
         when(spy(.equal("track"))).do({ value in
             captured.append(value)
         })
@@ -216,7 +215,6 @@ final class SpyTests: XCTestCase {
 
     func test_untilWaitsForAsyncInteraction() async throws {
         let spy = Spy<String, Async, Void>()
-        when(spy(.any)).thenReturn(())
 
         let waiter = Task {
             try await until(spy(.equal("ping")), timeout: .seconds(1))
@@ -230,7 +228,6 @@ final class SpyTests: XCTestCase {
 
     func test_untilAsyncTimesOutWhenNoCall() async {
         let spy = Spy<String, Async, Void>()
-        when(spy(.any)).thenReturn(())
 
         do {
             try await until(spy(.equal("never")), timeout: .milliseconds(50))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spies now initialize with a default provider automatically, reducing setup steps for common use cases.
  * Simplifies mocking by removing the need to manually register a default provider before first use.

* **Tests**
  * Streamlined test suite by removing blanket “any-call returns void” stubs, keeping tests focused on explicit behaviors. No functional changes for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->