### PR TITLE
Restate @unchecked Sendable in generated mocks and fix ArgMatcher concurrency warnings

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -16,14 +16,14 @@ public enum MockableGenerator {
     /// ```
     /// This function will generate the following structure:
     /// ```swift
-    ///class PricingServiceMock: Mock, PricingService {
+    /// class PricingServiceMock: Mock, @unchecked Sendable, PricingService {
     ///     func price(_ item: String) throws -> Int {
     ///         return try adaptThrowing(super.price, item)
     ///     }
     ///     func price(_ item: ArgMatcher<String>) -> Interaction<String, Throws, Int> {
     ///         Interaction(item, spy: super.price)
     ///     }
-    ///}
+    /// }
     /// ```
     public static func processProtocol(protocolDecl: ProtocolDeclSyntax) throws -> [DeclSyntax] {
         let protocolName = protocolDecl.name.text
@@ -46,6 +46,11 @@ public enum MockableGenerator {
         let interactions = makeInteractions(protocolDecl: protocolDecl)
         let conformanceRequirements = makeConformanceRequirements(for: protocolDecl)
 
+        var members = [MemberBlockItemSyntax]()
+        members.append(contentsOf: typeAliases.map { MemberBlockItemSyntax(decl: $0) })
+        members.append(contentsOf: interactions.map { MemberBlockItemSyntax(decl: $0) })
+        members.append(contentsOf: conformanceRequirements.map { MemberBlockItemSyntax(decl: $0) })
+
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
             name: TokenSyntax.identifier(mockName),
@@ -59,17 +64,23 @@ public enum MockableGenerator {
                         trailingComma: .commaToken()
                     ),
                     InheritedTypeSyntax(
+                        // `Mock` is `@unchecked Sendable`; subclasses must restate the
+                        // conformance to stay warning-free under Swift 6 concurrency.
+                        type: AttributedTypeSyntax(
+                            specifiers: [],
+                            attributes: [.attribute(
+                                AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("unchecked")))
+                            )],
+                            baseType: IdentifierTypeSyntax(name: TokenSyntax.identifier("Sendable"))
+                        ),
+                        trailingComma: .commaToken()
+                    ),
+                    InheritedTypeSyntax(
                         type: IdentifierTypeSyntax(name: protocolDecl.name)
                     )
                 ]
             ),
-            memberBlock: MemberBlockSyntax {
-                var members = [MemberBlockItemSyntax]()
-                members.append(contentsOf: typeAliases.map({ MemberBlockItemSyntax(decl: $0)}))
-                members.append(contentsOf: interactions.map { MemberBlockItemSyntax(decl: $0) })
-                members.append(contentsOf: conformanceRequirements.map { MemberBlockItemSyntax(decl: $0) })
-                return MemberBlockItemListSyntax(members)
-            }
+            memberBlock: MemberBlockSyntax(members: MemberBlockItemListSyntax(members))
         )
 
         let ifConfigDecl = ifConfig(MemberBlockItemListSyntax {

--- a/Sources/SwiftMocking/ArgMatcher.swift
+++ b/Sources/SwiftMocking/ArgMatcher.swift
@@ -257,9 +257,13 @@ public extension ArgMatcher where Argument: FloatingPoint & Sendable {
     /// // Verifying a method was called with a value close to 2.5
     /// verify(spy.calculate(.approximately(2.5))).called()
     /// ```
-    static func approximately(_ value: Argument, tolerance: Argument = 0.001) -> Self {
-        .init(precedence: .predicate) { argument in
-            abs(argument - value) <= tolerance
+    static func approximately(_ value: Argument, tolerance: Argument? = nil) -> Self {
+        // `1 / 1000` is expressible for any `FloatingPoint` (which refines
+        // `ExpressibleByIntegerLiteral`), avoiding default-expression inference
+        // that is an error in Swift 6 language mode.
+        let defaultTolerance: Argument = 1 / 1000
+        return .init(precedence: .predicate) { argument in
+            abs(argument - value) <= (tolerance ?? defaultTolerance)
         }
     }
 }
@@ -521,7 +525,7 @@ public extension ArgMatcher {
 }
 
 // MARK: - Collection
-public extension ArgMatcher where Argument: Collection {
+public extension ArgMatcher where Argument: Collection, Argument: Sendable {
     /// A matcher that matches an empty collection.
     ///
     /// ```swift
@@ -608,7 +612,7 @@ public extension ArgMatcher where Argument: Collection {
     }
 }
 
-public extension ArgMatcher where Argument: Collection, Argument.Element: Equatable & Sendable {
+public extension ArgMatcher where Argument: Collection, Argument: Sendable, Argument.Element: Equatable & Sendable {
     /// A matcher that matches a collection containing the given element.
     /// - Parameter element: The element to search for.
     ///

--- a/Tests/SwiftMockingMacrosTests/BasicTests.swift
+++ b/Tests/SwiftMockingMacrosTests/BasicTests.swift
@@ -20,7 +20,7 @@ final class BasicTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPricingService: Mock, PricingService {
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }

--- a/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
+++ b/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
@@ -20,7 +20,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPricingService: Mock, PricingService {
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }
@@ -48,7 +48,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPrinter: Mock, Printer {
+            class MockPrinter: Mock, @unchecked Sendable, Printer {
                 func print(_ values: ArgMatcher<String>...) -> Interaction<[String], None, Void> {
                     Interaction(.variadic(values), spy: super.print)
                 }
@@ -76,7 +76,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPricingService: Mock, PricingService {
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Throws, Int> {
                     Interaction(item, spy: super.price)
                 }
@@ -104,7 +104,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPricingService: Mock, PricingService {
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Async, Int> {
                     Interaction(item, spy: super.price)
                 }
@@ -132,7 +132,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPricingService: Mock, PricingService {
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, AsyncThrows, Int> {
                     Interaction(item, spy: super.price)
                 }
@@ -162,7 +162,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockFeedService: Mock, FeedService {
+            class MockFeedService: Mock, @unchecked Sendable, FeedService {
                 func fetch(from url: ArgMatcher<URL>) -> Interaction<URL, AsyncThrows, Data> {
                     Interaction(url, spy: super.fetch)
                 }
@@ -196,7 +196,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockService: Mock, Service {
+            class MockService: Mock, @unchecked Sendable, Service {
                 func doSomething() -> Interaction<Void, None, String> {
                     Interaction(.any, spy: super.doSomething)
                 }
@@ -224,7 +224,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockService: Mock, Service {
+            class MockService: Mock, @unchecked Sendable, Service {
                 func doSomething(with value: ArgMatcher<Int>) -> Interaction<Int, None, Void> {
                     Interaction(value, spy: super.doSomething)
                 }
@@ -252,7 +252,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockService: Mock, Service {
+            class MockService: Mock, @unchecked Sendable, Service {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
@@ -281,7 +281,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockLogger: Mock, Logger {
+            class MockLogger: Mock, @unchecked Sendable, Logger {
                 static func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                     Interaction(message, spy: super.log)
                 }
@@ -310,7 +310,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockAnalyticsProtocol: Mock, AnalyticsProtocol {
+            class MockAnalyticsProtocol: Mock, @unchecked Sendable, AnalyticsProtocol {
                 func logEvent<E: Identifiable>(_ event: ArgMatcher<E>) -> Interaction<E, None, Bool> {
                     Interaction(event, spy: super.logEvent)
                 }
@@ -338,7 +338,7 @@ final class FunctionSignatureTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockCallbackService: Mock, CallbackService {
+            class MockCallbackService: Mock, @unchecked Sendable, CallbackService {
                 func execute(completion: ArgMatcher<(String) -> Void>) -> Interaction<(String) -> Void, None, Void> {
                     Interaction(completion, spy: super.execute)
                 }

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -20,7 +20,7 @@ final class MacroOptionsTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockMyService: Mock, MyService {
+            class MockMyService: Mock, @unchecked Sendable, MyService {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
@@ -48,7 +48,7 @@ final class MacroOptionsTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MyServiceMock: Mock, MyService {
+            class MyServiceMock: Mock, @unchecked Sendable, MyService {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }

--- a/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
@@ -24,7 +24,7 @@ final class MockableMacroTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockPricingService: Mock, PricingService {
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -21,7 +21,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockService: Mock, Service {
+            class MockService: Mock, @unchecked Sendable, Service {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
@@ -49,7 +49,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockMyService: Mock, MyService {
+            class MockMyService: Mock, @unchecked Sendable, MyService {
                 func getValue() -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
@@ -80,7 +80,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockMyService: Mock, MyService {
+            class MockMyService: Mock, @unchecked Sendable, MyService {
                 required init(value: Int) {
                 }
             }
@@ -104,7 +104,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockMyService: Mock, MyService {
+            class MockMyService: Mock, @unchecked Sendable, MyService {
                 subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String > {
                     get {
                         Interaction(index, spy: super.subscript)
@@ -138,7 +138,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
             }
 
             #if DEBUG
-            class MockMyService<Item>: Mock, MyService {
+            class MockMyService<Item>: Mock, @unchecked Sendable, MyService {
                 typealias Item = Item
                 func item() -> Interaction<Void, None, Item> {
                     Interaction(.any, spy: super.item)

--- a/Tests/SwiftMockingTests/AssertTests.swift
+++ b/Tests/SwiftMockingTests/AssertTests.swift
@@ -275,7 +275,7 @@ final class AssertTests: XCTestCase {
 // MARK: - Test Mock for verifyZeroInteractions
 
 @dynamicMemberLookup
-class TestMock: Mock {
+class TestMock: Mock, @unchecked Sendable {
     var testMethod: Spy<String, None, Void> {
         self[dynamicMember: "testMethod"]
     }

--- a/Tests/SwiftMockingTests/MockTests.swift
+++ b/Tests/SwiftMockingTests/MockTests.swift
@@ -74,13 +74,13 @@ final class MockTests: MockingTestCase {
     }
 
     func testStatic() {
-        class LoggerMock: Mock {
+        class LoggerMock: Mock, @unchecked Sendable {
             static func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                 Interaction(message, spy: super.log)
             }
         }
 
-        class PrinterMock: Mock {
+        class PrinterMock: Mock, @unchecked Sendable {
             static func print(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                 Interaction(message, spy: super.print)
             }
@@ -117,13 +117,13 @@ final class MockTests: MockingTestCase {
         let logExpectation = XCTestExpectation(description: "log should not be called")
         logExpectation.isInverted = true
 
-        class LoggerMock: Mock {
+        class LoggerMock: Mock, @unchecked Sendable {
             func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                 Interaction(message, spy: super.log)
             }
         }
 
-        class PrinterMock: Mock {
+        class PrinterMock: Mock, @unchecked Sendable {
             func print(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                 Interaction(message, spy: super.print)
             }
@@ -193,7 +193,7 @@ final class MockTests: MockingTestCase {
         // Regression guard for P0-5: adapt() must not rewrite spy.defaultProviderRegistry
         // on every call. It raced concurrent invokes and the invoke-time read of the same
         // property; the registry is now captured once at spy creation.
-        final class AdapterMock: Mock {
+        final class AdapterMock: Mock, @unchecked Sendable {
             @discardableResult
             func echo(_ x: Int) -> Int { adapt(super.echo, x) }
         }
@@ -249,7 +249,7 @@ final class MockTests: MockingTestCase {
     func test_registryUpdatePropagatesToExistingSpies() {
         // Regression guard (PR review): spies created before the mock's registry changes
         // must observe the update — the adapters no longer refresh the registry per call.
-        final class RegistryMock: Mock {
+        final class RegistryMock: Mock, @unchecked Sendable {
             @discardableResult
             func echo() -> String { adapt(super.echo) }
         }


### PR DESCRIPTION
## Summary
- **Macro fix:** generated mock classes now declare `class FooMock: Mock, @unchecked Sendable, Foo`, so consumers no longer get "class must restate inherited '@unchecked Sendable' conformance" warnings (follow-up to #92 making the library Swift 6 data-race safe).
- **ArgMatcher cleanup:** collection matchers (`isEmpty`, `hasCount(...)`, `contains(...)`, ...) now require `Argument: Sendable`, fixing "capture of non-Sendable type 'Argument.Type' in an isolated closure" diagnostics.
- **`approximately`:** default tolerance moved to an optional parameter (`tolerance: Argument? = nil`, defaulting to `0.001`), removing the "cannot use default expression for inference" warning that is an error in Swift 6 language mode.
- Restated `@unchecked Sendable` on hand-written `Mock` subclasses in tests and updated all MacroTesting fixtures.

## Testing
- `swift build --build-tests` → **0 warnings, 0 errors**
- `swift test --parallel` → all suites pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated mocks now support Swift concurrency through explicit `@unchecked Sendable` conformance.
  * The approximate floating-point matcher accepts an optional tolerance and uses a default tolerance when omitted.
  * Collection matchers now enforce Sendable-safe collection and element types.
* **Tests**
  * Updated mock generation and concurrency test coverage for the new Sendable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->