### PR TITLE
Unify parameterless conformances on the (Void) input pack

### DIFF
--- a/GENERATED_CODE_EXAMPLES.md
+++ b/GENERATED_CODE_EXAMPLES.md
@@ -119,7 +119,7 @@ protocol Service {
 ```swift
 class ServiceMock: Mock, @unchecked Sendable, Service {
     func doSomething() {
-        return adapt(super.doSomething)
+        return adapt(super.doSomething, ())
     }
     func doSomething() -> Interaction<Void, None, Void> {
         Interaction(.any, spy: super.doSomething)
@@ -144,7 +144,7 @@ protocol MyService {
 ```swift
 class MockMyService: Mock, MyService {
     func doSomething() {
-        return adapt(super.doSomething)
+        return adapt(super.doSomething, ())
     }
     func doSomething() -> Interaction<Void, None, Void> {
         Interaction(.any, spy: super.doSomething)
@@ -171,7 +171,7 @@ protocol MyService {
 class MyServiceMock<Item>: Mock, MyService {
     typealias Item = Item
     func item() -> Item {
-        return adapt(super.item)
+        return adapt(super.item, ())
     }
     func item() -> Interaction<Void, None, Item> {
         Interaction(.any, spy: super.item)
@@ -196,7 +196,7 @@ class MyServiceMock: Mock, @unchecked Sendable, MyService {
 
     var value: Int {
         get {
-            adapt(super.value)
+            adapt(super.value, ())
         }
     }
     func getValue() -> Interaction<Void, None, Int > {
@@ -247,7 +247,7 @@ public protocol Service {
 ```swift
 class ServiceMock: Mock, @unchecked Sendable, Service {
     func doSomething() {
-        return adapt(super.doSomething)
+        return adapt(super.doSomething, ())
     }
     func doSomething() -> Interaction<Void, None, Void> {
         Interaction(.any, spy: super.doSomething)

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -241,13 +241,21 @@ extension MockableGenerator {
                     )
                 )
 
-                // param1, param2...
-                for parameter in parameters {
+                // param1, param2... — or () when the requirement has no
+                // parameters, so the spy's input pack stays (Void) and matches
+                // the pack spelled by the generated Interaction.
+                if parameters.isEmpty {
                     LabeledExprSyntax(
-                        expression: DeclReferenceExprSyntax.init(
-                            baseName: parameter
-                        )
+                        expression: TupleExprSyntax(elements: LabeledExprListSyntax())
                     )
+                } else {
+                    for parameter in parameters {
+                        LabeledExprSyntax(
+                            expression: DeclReferenceExprSyntax.init(
+                                baseName: parameter
+                            )
+                        )
+                    }
                 }
             },
             rightParen: .rightParenToken()

--- a/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
+++ b/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
@@ -201,7 +201,7 @@ final class FunctionSignatureTests: MacroTestCase {
                     Interaction(.any, spy: super.doSomething)
                 }
                 func doSomething() -> String {
-                    return adapt(super.doSomething)
+                    return adapt(super.doSomething, ())
                 }
             }
             #endif
@@ -257,7 +257,7 @@ final class FunctionSignatureTests: MacroTestCase {
                     Interaction(.any, spy: super.doSomething)
                 }
                 func doSomething() {
-                    return adapt(super.doSomething)
+                    return adapt(super.doSomething, ())
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -25,7 +25,7 @@ final class MacroOptionsTests: MacroTestCase {
                     Interaction(.any, spy: super.doSomething)
                 }
                 func doSomething() {
-                    return adapt(super.doSomething)
+                    return adapt(super.doSomething, ())
                 }
             }
             #endif
@@ -53,7 +53,7 @@ final class MacroOptionsTests: MacroTestCase {
                     Interaction(.any, spy: super.doSomething)
                 }
                 func doSomething() {
-                    return adapt(super.doSomething)
+                    return adapt(super.doSomething, ())
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -26,7 +26,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                     Interaction(.any, spy: super.doSomething)
                 }
                 func doSomething() {
-                    return adapt(super.doSomething)
+                    return adapt(super.doSomething, ())
                 }
             }
             #endif
@@ -56,7 +56,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                     var value: Int {
                     get {
-                        adapt(super.value)
+                        adapt(super.value, ())
                     }
                 }
             }
@@ -144,7 +144,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                     Interaction(.any, spy: super.item)
                 }
                 func item() -> Item {
-                    return adapt(super.item)
+                    return adapt(super.item, ())
                 }
             }
             #endif

--- a/Tests/SwiftMockingTests/ParameterlessInteractionTests.swift
+++ b/Tests/SwiftMockingTests/ParameterlessInteractionTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import SwiftMocking
+
+@Mockable
+protocol ParameterlessService {
+    func fire() -> Int
+    func ping()
+    var counter: Int { get }
+    func refresh() async -> String
+    func risky() throws -> Int
+}
+
+/// Regression tests for the empty-pack vs `(Void)`-pack spy split.
+///
+/// Requirements without parameters used to record invocations on a spy with an
+/// empty input pack (`Spy<Pack{}, ...>`), while the generated `Interaction`
+/// stubs and verifies a `(Void)`-pack spy (`Spy<Pack{()}, ...>`). The two are
+/// distinct specializations, so stubs never applied and verifications read zero.
+final class ParameterlessInteractionTests: XCTestCase {
+    func testZeroArgMethod_StubbedValueIsReturned() {
+        let mock = MockParameterlessService()
+        let service: ParameterlessService = mock
+        when(mock.fire()).thenReturn(42)
+
+        let result = service.fire()
+
+        XCTAssertEqual(result, 42)
+    }
+
+    func testZeroArgMethod_InvocationIsRecordedForVerification() {
+        let mock = MockParameterlessService()
+        let service: ParameterlessService = mock
+
+        service.ping()
+
+        verify(mock.ping()).called(1)
+    }
+
+    func testPropertyGetter_StubbedValueIsReturned() {
+        let mock = MockParameterlessService()
+        let service: ParameterlessService = mock
+        when(mock.getCounter()).thenReturn(7)
+
+        let result = service.counter
+
+        XCTAssertEqual(result, 7)
+    }
+
+    func testPropertyGetter_InvocationIsRecordedForVerification() {
+        let mock = MockParameterlessService()
+        let service: ParameterlessService = mock
+
+        _ = service.counter
+
+        verify(mock.getCounter()).called(1)
+    }
+
+    func testZeroArgAsyncMethod_StubbedValueIsReturned() async {
+        let mock = MockParameterlessService()
+        let service: ParameterlessService = mock
+        when(mock.refresh()).thenReturn("refreshed")
+
+        let result = await service.refresh()
+
+        XCTAssertEqual(result, "refreshed")
+    }
+
+    func testZeroArgThrowingMethod_StubbedValueIsReturned() throws {
+        let mock = MockParameterlessService()
+        let service: ParameterlessService = mock
+        when(mock.risky()).thenReturn(9)
+
+        let result = try service.risky()
+
+        XCTAssertEqual(result, 9)
+    }
+}

--- a/skills/swift-mocking/manual-mocking.md
+++ b/skills/swift-mocking/manual-mocking.md
@@ -43,23 +43,23 @@ Non-negotiables:
 | `async -> Int` | `return await adapt(super.f, x)` | `Async` |
 | `async throws -> Int` | `return try await adaptThrowing(super.f, x)` | `AsyncThrows` |
 
-Interaction generic arguments: **input types in order**, then the effect marker, then the output type (`Void` if none). Zero parameters → `Interaction<Void, Eff, Out>` with `Interaction(.any, spy: super.f)` — and the runtime member must use the pinned-spy form below, not `adapt(super.f)`.
+Interaction generic arguments: **input types in order**, then the effect marker, then the output type (`Void` if none). Zero parameters → `Interaction<Void, Eff, Out>` with `Interaction(.any, spy: super.f)` — and the runtime member must pass `()` explicitly (`adapt(super.f, ())`) to land on that same `(Void)`-pack spy.
 
-## Zero-parameter members and property getters — pinned-spy form
+## Zero-parameter members and property getters — pass `()` explicitly
 
-`adapt(super.f)` with **no arguments** infers an empty parameter pack, which resolves to a *different* spy than the interaction member's `Spy<Void, Eff, Out>`. Symptom: `when(mock.f()).thenReturn(v)` is silently ignored (unstubbed default returned) and `verify(mock.f()).called(n)` always sees 0 — even though the member ran. The macro-generated form has this defect; a manual mock fixes it by pinning the spy type:
+`adapt(super.f)` with **no arguments** infers an empty parameter pack, which resolves to a *different* spy than the interaction member's `Spy<Void, Eff, Out>`. Symptom: `when(mock.f()).thenReturn(v)` is silently ignored (unstubbed default returned) and `verify(mock.f()).called(n)` always sees 0 — even though the member ran. The macro emits `adapt(super.f, ())`; a manual mock must do the same:
 
 ```swift
 // protocol: func getStatus() -> String
 func getStatus() -> String {
-    let spy: Spy<Void, None, String> = super.getStatus
-    return spy(())
+    return adapt(super.getStatus, ())
 }
 func getStatus() -> Interaction<Void, None, String> {
     Interaction(.any, spy: super.getStatus)
 }
+```
 
-Effect variants: `return await spy(())` (Async), `return try spy(())` (Throws), `return try await spy(())` (AsyncThrows). Property getters use the same form keyed by the property name (see Properties). Prefer `spy(())` over the free function `adapt(spy)()` — the member `adapt` shadows it, forcing a `SwiftMocking.adapt` qualification.
+Effect variants: `return await adapt(super.getStatus, ())` (Async), `return try adaptThrowing(super.getStatus, ())` (Throws), `return try await adaptThrowing(super.getStatus, ())` (AsyncThrows). Property getters use the same form keyed by the property name (see Properties).
 
 
 ## Calling the mock — go through the protocol type
@@ -130,10 +130,9 @@ Getter interaction is `get` + capitalized name; setter is `set` + capitalized na
 // protocol: var cachePolicy: String { get set }
 var cachePolicy: String {
     get {
-        // Pinned-spy form — a bare `adapt(super.cachePolicy)` hits the zero-arg
-        // spy mismatch and getter stubs/verifies silently no-op.
-        let spy: Spy<Void, None, String> = super.cachePolicy
-        return spy(())
+        // Pass () explicitly — a bare `adapt(super.cachePolicy)` hits the
+        // zero-arg spy mismatch and getter stubs/verifies silently no-op.
+        adapt(super.cachePolicy, ())
     }
     set { return adapt(super.setCachePolicy, newValue) }
 }
@@ -236,7 +235,7 @@ func execute(completion: ArgMatcher<(String) -> Void>) -> Interaction<(String) -
 | Mistake | Symptom | Fix |
 |---|---|---|
 | Missing `@unchecked Sendable` restatement | Swift 6 warnings; fails `: Sendable` protocol conformance | `class FooMock: Mock, @unchecked Sendable, Foo` |
-| Zero-arg runtime member written as `adapt(super.f)` | Stub ignored; `verify(...)` always 0 (silent) | Pinned-spy form: `let spy: Spy<Void, Eff, O> = super.f; return spy(())` |
+| Zero-arg runtime member written as `adapt(super.f)` | Stub ignored; `verify(...)` always 0 (silent) | Pass `()`: `adapt(super.f, ())` — the form the macro emits |
 | Calling `mock.f()` bare on a zero-arg mock member | `ambiguous use of 'f()'` | Call through a protocol-typed reference |
 | Getter body `adapt(super.getX)` (wrong key or bare adapt) | Getter stubs/verifies silently no-op | Pin `Spy<Void, None, T>` keyed by the **property name** |
 | Setter body without `return` | `generic parameter 'Output' could not be inferred` | `set { return adapt(super.setX, newValue) }` — the `return` pins `Output == Void` |


### PR DESCRIPTION
## Summary
- Zero-parameter protocol methods and property getters generated `adapt(super.f)`, which infers an **empty** input pack and resolves to a different spy than the `(Void)`-pack spy the generated `Interaction` stubs and verifies (`Spy<Pack{}, …>` vs `Spy<Pack{()}, …>` — distinct specializations under the same storage key).
- Symptom: `when(mock.f()).thenReturn(v)` was silently ignored (default value returned) and `verify(mock.f()).called(n)` always read 0, even though the member ran.
- `adaptCall` now emits `()` for parameterless requirements so runtime members and interactions share one spy. Setter/subscript paths had parameters already and are unchanged.

## Test plan
- [x] New `ParameterlessInteractionTests` (6 tests through the real `@Mockable` macro): stub-value + verify-count for sync/async/throws zero-arg methods and property getters — all failed on the pre-fix generator, pass after (TDD red→green)
- [x] Updated macro expansion fixtures in `ProtocolFeaturesTests`, `FunctionSignatureTests`, `MacroOptionsTests`
- [x] Full suite: `swift test` — 176 passed, 0 failed

## Doc updates
- `GENERATED_CODE_EXAMPLES.md` regenerated examples
- `skills/swift-mocking/manual-mocking.md` no longer documents this as an open macro defect; manual mocks are told to pass `()` explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mocking support for parameterless methods and property getters, including async and throwing interactions.
  * Ensured generated mock calls handle zero-argument requirements consistently.

* **Documentation**
  * Updated manual mocking guidance and examples for parameterless members.

* **Tests**
  * Added regression coverage for stubbing and verifying parameterless mocked interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->