### PR TITLE
Generate getter interactions as Void-parameter overloads of the variable

### DIFF
--- a/Examples/Tests/ExamplesTests/ExampleXCTests.swift
+++ b/Examples/Tests/ExamplesTests/ExampleXCTests.swift
@@ -246,6 +246,19 @@ final class MockitoTests: XCTestCase {
         verify(mock[3]).called()
     }
 
+    func testPropertyService() {
+        let mock = MockPropertyService()
+
+        // Getter stubbing and verification read like the property itself
+        when(mock.value).thenReturn(42)
+        XCTAssertEqual(mock.value, 42)
+        verify(mock.value).called(1)
+
+        // Setter verification goes through setValue(newValue:)
+        mock.value = 7
+        verify(mock.setValue(newValue: .equal(7))).called(1)
+    }
+
     func testVariadic() {
         let mock = MockPrinter()
         (mock as Printer).print("hello", "___", "world")

--- a/Examples/Tests/ExamplesTests/ExamplesTests.swift
+++ b/Examples/Tests/ExamplesTests/ExamplesTests.swift
@@ -198,6 +198,19 @@ struct ExampleTests {
         verify(mock[3]).called()
     }
 
+    @Test func testPropertyService() {
+        let mock = MockPropertyService()
+
+        // Getter stubbing and verification read like the property itself
+        when(mock.value).thenReturn(42)
+        #expect(mock.value == 42)
+        verify(mock.value).called(1)
+
+        // Setter verification goes through setValue(newValue:)
+        mock.value = 7
+        verify(mock.setValue(newValue: .equal(7))).called(1)
+    }
+
     @Test func testNetworkService() async throws {
         let mock = MockNetworkService()
         let url = URL(string: "https://example.com/data")!

--- a/GENERATED_CODE_EXAMPLES.md
+++ b/GENERATED_CODE_EXAMPLES.md
@@ -192,15 +192,15 @@ protocol MyService {
 <summary>Generated Code</summary>
 
 ```swift
-class MyServiceMock: Mock, @unchecked Sendable, MyService {
+class MockMyService: Mock, @unchecked Sendable, MyService {
+    func value(_ void: Void) -> Interaction<Void, None, Int > {
+        Interaction(.any, spy: super.value)
+    }
 
-    var value: Int {
+        var value: Int {
         get {
             adapt(super.value, ())
         }
-    }
-    func getValue() -> Interaction<Void, None, Int > {
-        Interaction(.any, spy: super.value)
     }
 }
 ```

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -164,9 +164,16 @@ public extension MockableGenerator {
     /// func name(_ void: Void) -> Interaction<Void, None, String> { ... }
     /// ```
     ///
-    /// The `Void` parameter overloads the variable's own name so stubbing reads like a
-    /// property read (`when(mock.name)`), and it keeps the spy's input pack at `(Void)` —
-    /// the same pack the conformance's `adapt(super.name, ())` records on.
+    /// The `Void` parameter is load-bearing, not cosmetic:
+    /// - A niladic `func name()` alongside the conformance's `var name` property is an
+    ///   `invalid redeclaration` — the property's getter accessor already occupies the
+    ///   `name()` selector.
+    /// - The unapplied member reference `mock.name` then has exactly the type
+    ///   `(Void) -> Interaction<Void, None, T>`, which is what the `when`/`verify`
+    ///   overloads taking `(()) -> Interaction<repeat each Input, Eff, Output>` infer
+    ///   their input pack from, so `when(mock.name)` and `verify(mock.name)` resolve.
+    /// - It keeps the spy's input pack at `(Void)` — the same pack the conformance's
+    ///   `adapt(super.name, ())` records on.
     private static func createGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
         let interactionReturnType = createInteractionReturnType(inputTypes: [], outputType: type, effectType: .none, genericParameterClause: nil)
         let body = createFunctionBody(spyPropertyName: varName, parameterNames: [])

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -79,7 +79,7 @@ public extension MockableGenerator {
     ///
     /// For a variable `var name: String { get set }`, this will generate:
     /// ```swift
-    /// func getName() -> Interaction<Void, None, String> { ... }
+    /// func name(_ void: Void) -> Interaction<Void, None, String> { ... }
     /// func setName(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> { ... }
     /// ```
     private static func processVar(_ varDecl: VariableDeclSyntax) -> [DeclSyntax] {
@@ -161,16 +161,28 @@ public extension MockableGenerator {
     ///
     /// For a variable `var name: String`, this will generate:
     /// ```swift
-    /// func getName() -> Interaction<Void, None, String> { ... }
+    /// func name(_ void: Void) -> Interaction<Void, None, String> { ... }
     /// ```
+    ///
+    /// The `Void` parameter overloads the variable's own name so stubbing reads like a
+    /// property read (`when(mock.name)`), and it keeps the spy's input pack at `(Void)` —
+    /// the same pack the conformance's `adapt(super.name, ())` records on.
     private static func createGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
         let interactionReturnType = createInteractionReturnType(inputTypes: [], outputType: type, effectType: .none, genericParameterClause: nil)
         let body = createFunctionBody(spyPropertyName: varName, parameterNames: [])
+        let voidParameter = FunctionParameterSyntax(
+            firstName: .wildcardToken(),
+            secondName: .identifier("void"),
+            colon: .colonToken(trailingTrivia: .space),
+            type: IdentifierTypeSyntax(name: .identifier("Void"))
+        )
         return FunctionDeclSyntax(
             modifiers: modifiers.trimmed,
-            name: .identifier("get\(varName.capitalized)"),
+            name: .identifier(varName),
             signature: FunctionSignatureSyntax(
-                parameterClause: FunctionParameterClauseSyntax(parameters: []),
+                parameterClause: FunctionParameterClauseSyntax(
+                    parameters: FunctionParameterListSyntax([voidParameter])
+                ),
                 returnClause: interactionReturnType
             ),
             body: body

--- a/Sources/SwiftMocking/TestSupport.swift
+++ b/Sources/SwiftMocking/TestSupport.swift
@@ -29,6 +29,18 @@ public func when<each Input, Eff: Effect, Output>(_ interaction: Interaction<rep
     interaction.spy.when(calledWith: interaction.invocationMatcher)
 }
 
+///
+/// This overload accepts an unapplied reference to a parameterless interaction member —
+/// most notably a mocked variable's getter interaction — so stubbing reads like a plain
+/// property read:
+/// ```swift
+/// when(mock.name).thenReturn("mocked_value")
+/// ```
+public func when<each Input, Eff: Effect, Output>(_ interaction: (()) -> Interaction<repeat each Input, Eff, Output>) -> Arrange<repeat each Input, Eff, Output> {
+    let interaction = interaction(())
+    return interaction.spy.when(calledWith: interaction.invocationMatcher)
+}
+
 /// Verifies that a specific interaction with a mock object has occurred.
 ///
 /// This function is used to assert that a mocked method was called with arguments
@@ -49,6 +61,19 @@ public func verify<each Input, Eff: Effect, Output>(
     _ interaction: Interaction<repeat each Input, Eff, Output>
 ) -> Assert<repeat each Input, Eff, Output>  {
     Assert(invocationMatcher: interaction.invocationMatcher, spy: interaction.spy)
+}
+
+/// Verifies that a specific interaction with a mock object has occurred, accepting an
+/// unapplied reference to a parameterless interaction member (e.g. a mocked variable's
+/// getter interaction) so verification reads like a plain property read:
+/// ```swift
+/// verify(mock.name).called(1)
+/// ```
+public func verify<each Input, Eff: Effect, Output>(
+    _ interaction: (()) -> Interaction<repeat each Input, Eff, Output>
+) -> Assert<repeat each Input, Eff, Output> {
+    let interaction = interaction(())
+    return Assert(invocationMatcher: interaction.invocationMatcher, spy: interaction.spy)
 }
 
 /// Verifies that a sequence of interactions across multiple mock objects occurred in the specified order.
@@ -121,6 +146,17 @@ public func verifyInOrder(
 /// - Parameter line: The line where a verification failure is reported.
 public func verifyNever<each Input, Eff: Effect, Output>(
     _ interaction: Interaction<repeat each Input, Eff, Output>,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    verify(interaction).neverCalled(file: file, line: line)
+}
+
+/// Verifies that a specific interaction with a mock object never occurred, accepting an
+/// unapplied reference to a parameterless interaction member (e.g. a mocked variable's
+/// getter interaction): `verifyNever(mock.name)`.
+public func verifyNever<each Input, Eff: Effect, Output>(
+    _ interaction: (()) -> Interaction<repeat each Input, Eff, Output>,
     file: StaticString = #filePath,
     line: UInt = #line
 ) {

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -50,7 +50,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
             #if DEBUG
             class MockMyService: Mock, @unchecked Sendable, MyService {
-                func getValue() -> Interaction<Void, None, Int > {
+                func value(_ void: Void) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
 

--- a/Tests/SwiftMockingTests/ParameterlessInteractionTests.swift
+++ b/Tests/SwiftMockingTests/ParameterlessInteractionTests.swift
@@ -39,7 +39,7 @@ final class ParameterlessInteractionTests: XCTestCase {
     func testPropertyGetter_StubbedValueIsReturned() {
         let mock = MockParameterlessService()
         let service: ParameterlessService = mock
-        when(mock.getCounter()).thenReturn(7)
+        when(mock.counter).thenReturn(7)
 
         let result = service.counter
 
@@ -52,7 +52,13 @@ final class ParameterlessInteractionTests: XCTestCase {
 
         _ = service.counter
 
-        verify(mock.getCounter()).called(1)
+        verify(mock.counter).called(1)
+    }
+
+    func testPropertyGetter_NeverCalledVerification() {
+        let mock = MockParameterlessService()
+
+        verifyNever(mock.counter)
     }
 
     func testZeroArgAsyncMethod_StubbedValueIsReturned() async {

--- a/skills/swift-mocking/manual-mocking.md
+++ b/skills/swift-mocking/manual-mocking.md
@@ -104,7 +104,7 @@ public class AuthorizingUserServiceMock: Mock, @unchecked Sendable, AuthorizingU
     public func fetchUser(id: ArgMatcher<String>) -> Interaction<String, AsyncThrows, User> {
         Interaction(id, spy: super.fetchUser)
     }
-    public func getCachePolicy() -> Interaction<Void, None, String> {
+    public func cachePolicy(_ void: Void) -> Interaction<Void, None, String> {
         Interaction(.any, spy: super.cachePolicy)
     }
     public func setCachePolicy(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> {
@@ -124,7 +124,7 @@ Rules:
 
 ## Properties
 
-Getter interaction is `get` + capitalized name; setter is `set` + capitalized name.
+Getter interaction overloads the variable name with a `Void` parameter; setter is `set` + capitalized name.
 
 ```swift
 // protocol: var cachePolicy: String { get set }
@@ -136,7 +136,7 @@ var cachePolicy: String {
     }
     set { return adapt(super.setCachePolicy, newValue) }
 }
-func getCachePolicy() -> Interaction<Void, None, String> {
+func cachePolicy(_ void: Void) -> Interaction<Void, None, String> {
     Interaction(.any, spy: super.cachePolicy)
 }
 func setCachePolicy(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> {
@@ -144,7 +144,7 @@ func setCachePolicy(newValue: ArgMatcher<String>) -> Interaction<String, None, V
 }
 ```
 
-Read-only property → runtime getter + `getX()` interaction only.
+Read-only property → runtime getter + the `x(_ void: Void)` interaction only.
 
 ## Subscripts
 

--- a/skills/swift-mocking/manual-mocking.md
+++ b/skills/swift-mocking/manual-mocking.md
@@ -124,7 +124,7 @@ Rules:
 
 ## Properties
 
-Getter interaction overloads the variable name with a `Void` parameter; setter is `set` + capitalized name.
+Getter interaction overloads the variable name with a `Void` parameter; setter is `set` + capitalized name. The `Void` parameter is required, not cosmetic: a niladic `func cachePolicy()` next to the `var cachePolicy` conformance is an `invalid redeclaration` (the property's getter accessor already owns that selector), and the unapplied reference `mock.cachePolicy` must have exactly type `(Void) -> Interaction<…>` for `when(mock.cachePolicy)` / `verify(mock.cachePolicy)` to infer their input pack.
 
 ```swift
 // protocol: var cachePolicy: String { get set }

--- a/skills/swift-mocking/usage.md
+++ b/skills/swift-mocking/usage.md
@@ -66,7 +66,7 @@ when(cache[.any]).thenReturn("cached")       // subscript interactions via match
 verify(cache[.equal("key")]).called(1)
 ```
 
-Getter verification mirrors a read too: `verify(mock.isEnabled).called(1)` (also `verifyNever(mock.isEnabled)`). The getter interaction is an overload on the variable name taking `Void`; setter interactions keep the `setX(newValue:)` form. Bare zero-arg calls (`mock.f()`) on the mock type can be ambiguous between the runtime and interaction members — call through the protocol type.
+Getter verification mirrors a read too: `verify(mock.isEnabled).called(1)` (also `verifyNever(mock.isEnabled)`). The getter interaction is an overload on the variable name taking `Void` — the parameter is required: a niladic form would be an `invalid redeclaration` against the property's getter accessor, and it's what lets `when(mock.x)` infer its input pack. Setter interactions keep the `setX(newValue:)` form. Bare zero-arg calls (`mock.f()`) on the mock type can be ambiguous between the runtime and interaction members — call through the protocol type.
 
 ## Closure-based dependencies (TCA pattern)
 

--- a/skills/swift-mocking/usage.md
+++ b/skills/swift-mocking/usage.md
@@ -58,7 +58,7 @@ verifyInOrder([mock.auth(.any), mock.data(.any)])  // call order across spies
 ## Properties & subscripts
 
 ```swift
-when(mock.getIsEnabled()).thenReturn(true)   // getter interaction — getX()/setX(newValue:)
+when(mock.isEnabled).thenReturn(true)       // getter interaction — reads like the property itself
 mock.isEnabled = false
 verify(mock.setIsEnabled(newValue: .equal(false))).called(1)
 
@@ -66,9 +66,7 @@ when(cache[.any]).thenReturn("cached")       // subscript interactions via match
 verify(cache[.equal("key")]).called(1)
 ```
 
-⚠️ **Getter stubbing caveat (macro-generated mocks, current release)**: `when(mock.getX()).thenReturn(v)` does not reach the runtime getter — the getter returns the default value and `verify(mock.getX()).called(n)` always sees 0. Setters are unaffected. Hand-written mocks fix this with the pinned-spy getter form (see manual-mocking.md).
-
-⚠️ **Zero-parameter methods have the same defect in macro-generated mocks** — stub via `when(mock.f())` is ignored. Hand-written mocks: pinned-spy form. Bare zero-arg calls (`mock.f()`) on the mock type are ambiguous; call through the protocol type.
+Getter verification mirrors a read too: `verify(mock.isEnabled).called(1)` (also `verifyNever(mock.isEnabled)`). The getter interaction is an overload on the variable name taking `Void`; setter interactions keep the `setX(newValue:)` form. Bare zero-arg calls (`mock.f()`) on the mock type can be ambiguous between the runtime and interaction members — call through the protocol type.
 
 ## Closure-based dependencies (TCA pattern)
 


### PR DESCRIPTION
## Summary
- Property getter interactions change from `getValue()` to `value(_ void: Void) -> Interaction<Void, None, T>`, overloading the variable name so stubbing and verification read like property access:
  ```swift
  when(mock.value).thenReturn(3)
  verify(mock.value).called(1)
  verifyNever(mock.value)
  ```
- New `when`/`verify`/`verifyNever` overloads accept an unapplied parameterless interaction reference (`(()) -> Interaction`).
- The `Void` parameter is load-bearing and now documented (generator doc comment + skill notes): a niladic `func value()` is an `invalid redeclaration` against the property's getter accessor (owns the `value()` selector), and the one-`Void`-param form gives `mock.value` exactly the `(Void) -> Interaction<Void, None, T>` type the pack inference in the closure overloads requires.
- Keeps the spy's input pack at `(Void)`, matching the conformance's `adapt(super.value, ())` from #95 — no pack-split regression.
- Setter interactions keep the `setX(newValue:)` form; a follow-up pass will overload those onto the variable name too.

## Test plan
- [x] TDD: `when(mock.counter)` / `verify(mock.counter)` / `verifyNever(mock.counter)` updated first — failed to compile (only an `Int` property existed), green after generator + runtime changes
- [x] Property expansion fixture pinned against actual macro output
- [x] Full suite: `swift test` — 176 passed, 0 failed

## Doc updates
- `GENERATED_CODE_EXAMPLES.md` property example
- `skills/swift-mocking/manual-mocking.md`, `skills/swift-mocking/usage.md` — new interaction form, `Void`-parameter rationale, dropped the fixed getter/zero-parameter caveats

⚠️ Breaking: call sites using `getX()` for stubbing/verification must switch to `when(mock.x)` (or `mock.x(())`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct property getter support for stubbing and verification.
  * Added `when`, `verify`, and `verifyNever` support for parameterless property interactions.
  * Property setters continue to support assignment and verification.

* **Documentation**
  * Updated property-mocking guidance and examples to use direct property access.
  * Clarified getter verification, overload usage, and read-only property handling.

* **Tests**
  * Added coverage for property getter and setter behavior, including unused getter verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->