### PR TITLE
Add mockable CLI for deterministic mock generation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,10 @@ let package = Package(
             name: "SwiftMockingTestSupport",
             targets: ["SwiftMockingTestSupport"]
         ),
+        .executable(
+            name: "mockable",
+            targets: ["MockableCLI"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"602.0.0"),
@@ -69,8 +73,18 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
+                .product(name: "SwiftDiagnostics", package: "swift-syntax"),
                 "SwiftMockingOptions",
             ]
+        ),
+        .executableTarget(
+            name: "MockableCLI",
+            dependencies: [
+                "MockableGenerator",
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .macro(
             name: "SwiftMockingMacros",
@@ -91,6 +105,7 @@ let package = Package(
         .testTarget(name: "SwiftMockingMacrosTests", dependencies: [
             "SwiftMocking",
             "SwiftMockingMacros",
+            "MockableGenerator",
             .product(name: "MacroTesting", package: "swift-macro-testing"),
             .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
         ], swiftSettings: [.swiftLanguageMode(.v6)])

--- a/README.md
+++ b/README.md
@@ -625,6 +625,19 @@ ln -s "$(pwd)/swift-mocking/skills/swift-mocking" ~/.agents/skills/swift-mocking
 
 Once installed, the skill activates automatically when the agent works on Swift tests that use SwiftMocking (or needs a mock the macro can't generate). No prompt changes required.
 
+### Mock Generation CLI
+
+The package includes a `mockable` executable that runs the same code generation as the `@Mockable` macro, outside the compiler. It reads a protocol definition from stdin and writes the generated mock class to stdout — useful for agents and codegen pipelines, or when you want the mock source materialized:
+
+```bash
+echo 'protocol PricingService { func price(_ item: String) throws -> Int }' | swift run mockable
+```
+
+- Output is byte-identical to `@Mockable` macro expansion, including the `#if DEBUG` wrapper. Generation options are read from a `@Mockable` attribute on the input protocol when present (e.g. `@Mockable([.suffixMock])`); protocols without one use the default options.
+- Every top-level protocol declaration in the input gets a mock, emitted in declaration order.
+- Warnings go to stderr (e.g. a protocol that inherits another protocol — inherited requirements are not implemented); stdout only ever contains generated code.
+- Exits non-zero, with annotated diagnostics on stderr, when the input does not parse as Swift or declares no protocol.
+
 ---
 
 ## ⚙️ How it Works

--- a/README.md
+++ b/README.md
@@ -627,11 +627,21 @@ Once installed, the skill activates automatically when the agent works on Swift 
 
 ### Mock Generation CLI
 
-The package includes a `mockable` executable that runs the same code generation as the `@Mockable` macro, outside the compiler. It reads a protocol definition from stdin and writes the generated mock class to stdout — useful for agents and codegen pipelines, or when you want the mock source materialized:
+The package includes a `mockable` executable that runs the same code generation as the `@Mockable` macro, outside the compiler. It reads a protocol definition from stdin and writes the generated mock class to stdout — useful for agents and codegen pipelines, or when you want the mock source materialized.
+
+**Install (recommended):** build the release binary once from a clone of this repository — startup is near-instant on every subsequent run:
 
 ```bash
-echo 'protocol PricingService { func price(_ item: String) throws -> Int }' | swift run mockable
+swift build -c release --product mockable   # → .build/release/mockable
 ```
+
+Then pipe protocol definitions through it:
+
+```bash
+echo 'protocol PricingService { func price(_ item: String) throws -> Int }' | .build/release/mockable
+```
+
+For one-off use without building first, `swift run mockable` works the same way but pays SwiftPM planning overhead on each invocation.
 
 - Output is byte-identical to `@Mockable` macro expansion, including the `#if DEBUG` wrapper. Generation options are read from a `@Mockable` attribute on the input protocol when present (e.g. `@Mockable([.suffixMock])`); protocols without one use the default options.
 - Every top-level protocol declaration in the input gets a mock, emitted in declaration order.

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ echo 'protocol PricingService { func price(_ item: String) throws -> Int }' | .b
 
 For one-off use without building first, `swift run mockable` works the same way but pays SwiftPM planning overhead on each invocation.
 
-- Output is byte-identical to `@Mockable` macro expansion, including the `#if DEBUG` wrapper. Generation options are read from a `@Mockable` attribute on the input protocol when present (e.g. `@Mockable([.suffixMock])`); protocols without one use the default options.
+- Default output keeps the `#if DEBUG` wrapper the macro emits; pass `--no-debug-wrap` to emit the mock bare — the right choice when pasting into a test target, since `DEBUG` is defined per build configuration (a wrapped mock would vanish under `swift test -c release`).
 - Every top-level protocol declaration in the input gets a mock, emitted in declaration order.
 - Warnings go to stderr (e.g. a protocol that inherits another protocol — inherited requirements are not implemented); stdout only ever contains generated code.
 - Exits non-zero, with annotated diagnostics on stderr, when the input does not parse as Swift or declares no protocol.

--- a/README.md
+++ b/README.md
@@ -641,6 +641,12 @@ Then pipe protocol definitions through it:
 echo 'protocol PricingService { func price(_ item: String) throws -> Int }' | .build/release/mockable
 ```
 
+To make the tool available everywhere (recommended for agents), copy the binary onto your `PATH`:
+
+```bash
+cp .build/release/mockable /opt/homebrew/bin/   # or any dir on your PATH
+```
+
 For one-off use without building first, `swift run mockable` works the same way but pays SwiftPM planning overhead on each invocation.
 
 - Default output keeps the `#if DEBUG` wrapper the macro emits; pass `--no-debug-wrap` to emit the mock bare — the right choice when pasting into a test target, since `DEBUG` is defined per build configuration (a wrapped mock would vanish under `swift test -c release`).

--- a/Sources/MockableCLI/main.swift
+++ b/Sources/MockableCLI/main.swift
@@ -16,6 +16,11 @@ Generation options are read from a `@Mockable` attribute on each protocol,
 when present (e.g. `@Mockable([.suffixMock])`). Protocols without the
 attribute use the default options.
 
+By default output keeps the `#if DEBUG` wrapper the macro emits. Pass
+--no-debug-wrap to emit the mock class bare — the right choice when pasting
+into a test target, since DEBUG is defined per build configuration (not per
+target) and a wrapped mock vanishes under `swift test -c release`.
+
 Example:
   echo 'protocol PricingService { func price(_ item: String) -> Int }' | mockable
 
@@ -51,17 +56,21 @@ func printWarnings(for mocks: [GeneratedMock]) {
     }
 }
 
-func run() throws {
-    let mocks = try MockableGenerator.generateMocks(source: readStdin())
+func run(includeDebugWrapper: Bool) throws {
+    let mocks = try MockableGenerator.generateMocks(
+        source: readStdin(),
+        includeDebugWrapper: includeDebugWrapper
+    )
     printWarnings(for: mocks)
     print(mocks.map(\.source).joined(separator: "\n\n"))
 }
 
 do {
-    if CommandLine.arguments.dropFirst().contains(where: { $0 == "-h" || $0 == "--help" }) {
+    let arguments = CommandLine.arguments.dropFirst()
+    if arguments.contains(where: { $0 == "-h" || $0 == "--help" }) {
         print(usage)
     } else {
-        try run()
+        try run(includeDebugWrapper: !arguments.contains("--no-debug-wrap"))
     }
 } catch {
     FileHandle.standardError.write(Data("error: \(error)\n".utf8))

--- a/Sources/MockableCLI/main.swift
+++ b/Sources/MockableCLI/main.swift
@@ -65,10 +65,17 @@ func run(includeDebugWrapper: Bool) throws {
     print(mocks.map(\.source).joined(separator: "\n\n"))
 }
 
+let supportedArguments: Set<String> = ["--no-debug-wrap"]
+
 do {
-    let arguments = CommandLine.arguments.dropFirst()
+    let arguments = Array(CommandLine.arguments.dropFirst())
     if arguments.contains(where: { $0 == "-h" || $0 == "--help" }) {
         print(usage)
+    } else if let unsupported = arguments.first(where: { !supportedArguments.contains($0) }) {
+        FileHandle.standardError.write(
+            Data("error: unsupported argument '\(unsupported)'\n\n\(usage)\n".utf8)
+        )
+        exit(1)
     } else {
         try run(includeDebugWrapper: !arguments.contains("--no-debug-wrap"))
     }

--- a/Sources/MockableCLI/main.swift
+++ b/Sources/MockableCLI/main.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+import MockableGenerator
+
+let usage = """
+usage: mockable
+
+Reads Swift source from stdin and writes a mock class for every top-level
+protocol declaration to stdout. Output is byte-identical to what the
+`@Mockable` macro expands to, including the `#if DEBUG` wrapper.
+
+Generation options are read from a `@Mockable` attribute on each protocol,
+when present (e.g. `@Mockable([.suffixMock])`). Protocols without the
+attribute use the default options.
+
+Example:
+  echo 'protocol PricingService { func price(_ item: String) -> Int }' | mockable
+
+Exit status:
+  0  success
+  1  input is not valid Swift or declares no protocol
+
+Warnings (e.g. a protocol that inherits another protocol, whose inherited
+requirements the generator does not implement) are written to stderr; stdout
+only ever carries generated code.
+"""
+
+func readStdin() throws -> String {
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    guard let source = String(data: data, encoding: .utf8) else {
+        throw MockableGeneratorError.parseFailed(diagnostics: "input is not valid UTF-8")
+    }
+    return source
+}
+
+func printWarnings(for mocks: [GeneratedMock]) {
+    for mock in mocks {
+        for inheritedTypeName in mock.inheritedTypeNames {
+            FileHandle.standardError.write(
+                Data(
+                    (
+                        "warning: mock for protocol '\(mock.protocolName)' does not implement " +
+                        "requirements inherited from '\(inheritedTypeName)' and may fail to conform\n"
+                    ).utf8
+                )
+            )
+        }
+    }
+}
+
+func run() throws {
+    let mocks = try MockableGenerator.generateMocks(source: readStdin())
+    printWarnings(for: mocks)
+    print(mocks.map(\.source).joined(separator: "\n\n"))
+}
+
+do {
+    if CommandLine.arguments.dropFirst().contains(where: { $0 == "-h" || $0 == "--help" }) {
+        print(usage)
+    } else {
+        try run()
+    }
+} catch {
+    FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+    exit(1)
+}

--- a/Sources/MockableCLI/main.swift
+++ b/Sources/MockableCLI/main.swift
@@ -5,6 +5,9 @@ import MockableGenerator
 let usage = """
 usage: mockable
 
+Build once with: swift build -c release --product mockable
+Binary: .build/release/mockable
+
 Reads Swift source from stdin and writes a mock class for every top-level
 protocol declaration to stdout. Output is byte-identical to what the
 `@Mockable` macro expands to, including the `#if DEBUG` wrapper.

--- a/Sources/MockableGenerator/MockableGenerator+Source.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Source.swift
@@ -57,14 +57,16 @@ public extension MockableGenerator {
     ///
     /// Options are read from a `@Mockable` attribute on each protocol, when
     /// present. A protocol without the attribute uses the default options.
-    ///
     /// - Parameter source: Swift source text containing at least one top-level
     ///   protocol declaration.
+    /// - Parameter includeDebugWrapper: When `true` (the default) output keeps
+    ///   the `#if DEBUG` wrapper the macro emits. Pass `false` to emit the mock
+    ///   class bare — appropriate for mocks pasted into test targets, which
+    ///   have no release build to strip (note `DEBUG` is defined per build
+    ///   configuration, not per target, so a bare mock also survives
+    ///   `swift test -c release`).
     /// - Returns: One `GeneratedMock` per protocol, in declaration order.
-    /// - Throws: `MockableGeneratorError.parseFailed` if the source has syntax
-    ///   errors, `MockableGeneratorError.noProtocolsFound` if it declares no
-    ///   top-level protocols.
-    static func generateMocks(source: String) throws -> [GeneratedMock] {
+    static func generateMocks(source: String, includeDebugWrapper: Bool = true) throws -> [GeneratedMock] {
         let sourceFile = Parser.parse(source: source)
 
         let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: sourceFile)
@@ -78,9 +80,17 @@ public extension MockableGenerator {
         guard !protocolDecls.isEmpty else {
             throw MockableGeneratorError.noProtocolsFound
         }
-
         return try protocolDecls.map { protocolDecl in
             let mockSource = try processProtocol(protocolDecl: protocolDecl)
+                .flatMap { decl -> [DeclSyntax] in
+                    guard !includeDebugWrapper, let ifConfig = decl.as(IfConfigDeclSyntax.self) else {
+                        return [decl]
+                    }
+                    guard case .decls(let members)? = ifConfig.clauses.first?.elements else {
+                        return [decl]
+                    }
+                    return members.map(\.decl)
+                }
                 .map { decl in
                     decl.formatted(using: BasicFormat(indentationWidth: .spaces(4)))
                         .trimmedDescription(matching: \.isWhitespace)

--- a/Sources/MockableGenerator/MockableGenerator+Source.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Source.swift
@@ -1,0 +1,106 @@
+import SwiftBasicFormat
+import SwiftDiagnostics
+import SwiftParser
+import SwiftParserDiagnostics
+import SwiftSyntax
+
+import SwiftMockingOptions
+
+/// The result of generating a mock for a single protocol declaration.
+public struct GeneratedMock: Equatable, Sendable {
+    /// The name of the protocol the mock was generated from.
+    public let protocolName: String
+
+    /// The formatted mock declaration, including its `#if DEBUG` wrapper.
+    public let source: String
+
+    /// Names of protocols the source protocol inherits, excluding memberless
+    /// bases (`AnyObject`, `class`, `Sendable`).
+    ///
+    /// Non-empty when the generated mock may fail to conform, because the
+    /// generator does not emit implementations for inherited requirements.
+    public let inheritedTypeNames: [String]
+
+    public init(protocolName: String, source: String, inheritedTypeNames: [String]) {
+        self.protocolName = protocolName
+        self.source = source
+        self.inheritedTypeNames = inheritedTypeNames
+    }
+}
+
+/// Errors thrown while generating mocks from Swift source.
+public enum MockableGeneratorError: Error, Equatable, CustomStringConvertible {
+    /// The input parsed successfully but contains no top-level protocol declaration.
+    case noProtocolsFound
+
+    /// The input is not valid Swift. The payload carries compiler-style
+    /// annotated diagnostics describing every parse error.
+    case parseFailed(diagnostics: String)
+
+    public var description: String {
+        switch self {
+        case .noProtocolsFound:
+            "no protocol declaration found in input"
+        case .parseFailed(let diagnostics):
+            "input failed to parse as Swift:\n\(diagnostics)"
+        }
+    }
+}
+
+public extension MockableGenerator {
+    /// Generates a mock class for every top-level protocol declaration in the given Swift source.
+    ///
+    /// This is the pipeline behind the `mockable` command line tool. It parses
+    /// the source, runs the same generation used by the `@Mockable` macro, and
+    /// formats the result exactly like macro expansion output, so mocks
+    /// generated here are byte-identical to their macro-generated counterparts.
+    ///
+    /// Options are read from a `@Mockable` attribute on each protocol, when
+    /// present. A protocol without the attribute uses the default options.
+    ///
+    /// - Parameter source: Swift source text containing at least one top-level
+    ///   protocol declaration.
+    /// - Returns: One `GeneratedMock` per protocol, in declaration order.
+    /// - Throws: `MockableGeneratorError.parseFailed` if the source has syntax
+    ///   errors, `MockableGeneratorError.noProtocolsFound` if it declares no
+    ///   top-level protocols.
+    static func generateMocks(source: String) throws -> [GeneratedMock] {
+        let sourceFile = Parser.parse(source: source)
+
+        let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: sourceFile)
+        if diagnostics.contains(where: { $0.diagMessage.severity == .error }) {
+            throw MockableGeneratorError.parseFailed(
+                diagnostics: DiagnosticsFormatter.annotatedSource(tree: sourceFile, diags: diagnostics)
+            )
+        }
+
+        let protocolDecls = sourceFile.statements.compactMap { $0.item.as(ProtocolDeclSyntax.self) }
+        guard !protocolDecls.isEmpty else {
+            throw MockableGeneratorError.noProtocolsFound
+        }
+
+        return try protocolDecls.map { protocolDecl in
+            let mockSource = try processProtocol(protocolDecl: protocolDecl)
+                .map { decl in
+                    decl.formatted(using: BasicFormat(indentationWidth: .spaces(4)))
+                        .trimmedDescription(matching: \.isWhitespace)
+                }
+                .joined(separator: "\n\n")
+
+            return GeneratedMock(
+                protocolName: protocolDecl.name.text,
+                source: mockSource,
+                inheritedTypeNames: inheritedTypeNames(of: protocolDecl)
+            )
+        }
+    }
+
+    /// Collects the protocols a declaration inherits, dropping bases that
+    /// carry no requirements (`AnyObject`, `class`, `Sendable`).
+    private static func inheritedTypeNames(of protocolDecl: ProtocolDeclSyntax) -> [String] {
+        let memberlessBases: Set<String> = ["AnyObject", "class", "Sendable"]
+        return protocolDecl.inheritanceClause?.inheritedTypes
+            .map { $0.type.trimmedDescription }
+            .filter { !memberlessBases.contains($0) } ?? []
+    }
+}

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -155,4 +155,30 @@ final class GeneratorPipelineTests: XCTestCase {
             XCTAssertTrue(diagnostics.contains("error:"), "diagnostics should annotate errors: \(diagnostics)")
         }
     }
+
+    func testGenerateMocksWithoutDebugWrapperOmitsIfConfigAndKeepsMembers() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable()
+            protocol PricingService {
+                func price(_ item: String) -> Int
+            }
+            """,
+            includeDebugWrapper: false
+        )
+
+        XCTAssertEqual(mocks.map(\.source), [
+            """
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
+                func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
+                    Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) -> Int {
+                    return adapt(super.price, item)
+                }
+            }
+            """
+        ])
+    }
+
 }

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+
+import MockableGenerator
+
+/// Tests that `MockableGenerator.generateMocks(source:)` — the pipeline behind the
+/// `mockable` CLI — produces output byte-identical to the fixtures pinned by the
+/// `@Mockable` macro expansion tests.
+final class GeneratorPipelineTests: XCTestCase {
+    func testGenerateMocksForSingleMethodMatchesMacroExpansion() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable()
+            protocol PricingService {
+                func price(_ item: String) -> Int
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks.map(\.protocolName), ["PricingService"])
+        XCTAssertEqual(mocks.map(\.source), [
+            """
+            #if DEBUG
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
+                func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
+                    Interaction(item, spy: super.price)
+                }
+                func price(_ item: String) -> Int {
+                    return adapt(super.price, item)
+                }
+            }
+            #endif
+            """
+        ])
+    }
+
+    func testGenerateMocksForPropertyMatchesMacroExpansion() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable()
+            protocol MyService {
+                var value: Int { get }
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks.map(\.source), [
+            """
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                func value(_ void: Void) -> Interaction<Void, None, Int > {
+                    Interaction(.any, spy: super.value)
+                }
+
+                    var value: Int {
+                    get {
+                        adapt(super.value, ())
+                    }
+                }
+            }
+            #endif
+            """
+        ])
+    }
+
+    func testGenerateMocksHonorsOptionsFromAttribute() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable([.suffixMock])
+            protocol MyService {
+                func doSomething()
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks.map(\.source), [
+            """
+            #if DEBUG
+            class MyServiceMock: Mock, @unchecked Sendable, MyService {
+                func doSomething() -> Interaction<Void, None, Void> {
+                    Interaction(.any, spy: super.doSomething)
+                }
+                func doSomething() {
+                    return adapt(super.doSomething, ())
+                }
+            }
+            #endif
+            """
+        ])
+    }
+
+    func testGenerateMocksForProtocolWithoutAttributeUsesDefaultPrefix() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            protocol MyService {
+                func doSomething()
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks.map(\.protocolName), ["MyService"])
+        XCTAssertTrue(mocks[0].source.contains("class MockMyService:"))
+    }
+
+    func testGenerateMocksForMultipleProtocolsPreservesDeclarationOrder() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            struct NotAProtocol {}
+
+            protocol First {
+                func first()
+            }
+
+            enum AlsoNotAProtocol {}
+
+            protocol Second {
+                func second()
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks.map(\.protocolName), ["First", "Second"])
+        XCTAssertEqual(mocks.map(\.inheritedTypeNames), [[], []])
+    }
+
+    func testGenerateMocksReportsInheritedTypeNamesWithoutMemberlessBases() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            protocol Second: First, Sendable, AnyObject {
+                func second()
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks[0].inheritedTypeNames, ["First"])
+    }
+
+    func testGenerateMocksThrowsWhenNoProtocolDeclarationPresent() {
+        XCTAssertThrowsError(
+            try MockableGenerator.generateMocks(source: "struct Foo {}")
+        ) { error in
+            XCTAssertEqual(
+                error as? MockableGeneratorError,
+                .noProtocolsFound
+            )
+        }
+    }
+
+    func testGenerateMocksThrowsAnnotatedDiagnosticsForMalformedInput() {
+        XCTAssertThrowsError(
+            try MockableGenerator.generateMocks(source: "protocol {")
+        ) { error in
+            guard case let .parseFailed(diagnostics) = error as? MockableGeneratorError else {
+                return XCTFail("expected parseFailed, got \(error)")
+            }
+            XCTAssertTrue(diagnostics.contains("error:"), "diagnostics should annotate errors: \(diagnostics)")
+        }
+    }
+}

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -32,7 +32,7 @@ Invoke as `mockable` when it is on `PATH`; otherwise `.build/release/mockable` i
 - Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin.
 - Default output keeps the macro's `#if DEBUG` wrapper; pass `--no-debug-wrap` when pasting into a test target (DEBUG is per build configuration — a wrapped mock vanishes under `swift test -c release`).
 - A stderr warning about inherited requirements means the output will not conform — hand-write per manual-mocking.md instead.
-- Output keeps the macro's zero-arg/property-getter shape, which `when`/`verify` silently mis-stub — apply the pinned-spy fix from manual-mocking.md before relying on those members.
+- Output keeps the macro's zero-arg/property-getter shape: `when(...)` silently stubs a disconnected spy, and `verify(...)` reports zero calls for those members — apply the pinned-spy fix from manual-mocking.md before relying on them.
 
 ## The one rule for manual mocks
 

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -14,9 +14,26 @@ Mocking for Swift protocols: `@Mockable` generates mock classes; `when(...)` stu
 | Protocol has no inheritance; need a mock | `@Mockable protocol P {...}` → use `PMock()` |
 | Protocol inherits another protocol with members | **manual-mocking.md** (macro cannot do this) |
 | Mocking without any protocol (closure/TCA dependencies) | usage.md — `Spy` + `adapt` |
-| Hand-writing any mock (macro-free, or macro plugin unavailable) | manual-mocking.md |
+| Need mock source without the macro (plugin unavailable, codegen, review) | `mockable` CLI (below) when available; hand-writing per manual-mocking.md is always valid |
 | `@Sendable`/Swift 6 concurrency errors when stubbing | sendable.md |
 | Stubbing / matching / verifying API reference | usage.md |
+
+
+## Deterministic generation: the `mockable` CLI
+
+When a mock must exist as written source (macro plugin unavailable, codegen pipeline, review), the `mockable` CLI is the fastest exact path — it needs a swift-mocking checkout and a one-time build. Hand-writing per manual-mocking.md is equally correct and needs nothing; use the CLI when it's available, hand-write when it isn't or when you're already customizing. Build once:
+
+```bash
+swift build -c release --product mockable   # → .build/release/mockable
+```
+
+```bash
+echo 'protocol P { func price(_ item: String) throws -> Int }' | .build/release/mockable
+```
+
+- Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin.
+- A stderr warning about inherited requirements means the output will not conform — hand-write per manual-mocking.md instead.
+- Output keeps the macro's zero-arg/property-getter shape, which `when`/`verify` silently mis-stub — apply the pinned-spy fix from manual-mocking.md before relying on those members.
 
 ## The one rule for manual mocks
 

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -32,6 +32,7 @@ echo 'protocol P { func price(_ item: String) throws -> Int }' | .build/release/
 ```
 
 - Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin.
+- Default output keeps the macro's `#if DEBUG` wrapper; pass `--no-debug-wrap` when pasting into a test target (DEBUG is per build configuration — a wrapped mock vanishes under `swift test -c release`).
 - A stderr warning about inherited requirements means the output will not conform — hand-write per manual-mocking.md instead.
 - Output keeps the macro's zero-arg/property-getter shape, which `when`/`verify` silently mis-stub — apply the pinned-spy fix from manual-mocking.md before relying on those members.
 

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -21,15 +21,13 @@ Mocking for Swift protocols: `@Mockable` generates mock classes; `when(...)` stu
 
 ## Deterministic generation: the `mockable` CLI
 
-When a mock must exist as written source (macro plugin unavailable, codegen pipeline, review), the `mockable` CLI is the fastest exact path — it needs a swift-mocking checkout and a one-time build. Hand-writing per manual-mocking.md is equally correct and needs nothing; use the CLI when it's available, hand-write when it isn't or when you're already customizing. Build once:
+When a mock must exist as written source (macro plugin unavailable, codegen pipeline, review), the `mockable` CLI is the fastest exact path. Hand-writing per manual-mocking.md is equally correct and needs nothing; use the CLI when it's available, hand-write when it isn't or when you're already customizing.
 
 ```bash
-swift build -c release --product mockable   # → .build/release/mockable
+echo 'protocol P { func price(_ item: String) throws -> Int }' | mockable
 ```
 
-```bash
-echo 'protocol P { func price(_ item: String) throws -> Int }' | .build/release/mockable
-```
+Invoke as `mockable` when it is on `PATH`; otherwise `.build/release/mockable` inside a swift-mocking checkout (build once with `swift build -c release --product mockable`, then optionally copy the binary onto `PATH`).
 
 - Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin.
 - Default output keeps the macro's `#if DEBUG` wrapper; pass `--no-debug-wrap` when pasting into a test target (DEBUG is per build configuration — a wrapped mock vanishes under `swift test -c release`).

--- a/skills/swift-mocking/manual-mocking.md
+++ b/skills/swift-mocking/manual-mocking.md
@@ -6,6 +6,8 @@ How to hand-write what `@Mockable` generates — without the macro. Required whe
 - Macro plugin unavailable (locked-down toolchains, codegen restrictions).
 - One-off customization inside a mock.
 
+Hand-writing is always a valid option, with or without the `mockable` CLI. For protocols **without** inheritance, generating the base with the CLI (see SKILL.md) is faster and byte-exact — use it when available, then hand-adjust.
+
 Everything below mirrors `MockableGenerator` — with one deliberate improvement: zero-parameter members and property getters use the pinned-spy form so `when`/`verify` actually reach them (the macro-generated form silently mis-stubs those; see the pinned-spy section).
 
 ## The two-member rule


### PR DESCRIPTION
## Summary

- Add a `mockable` executable product: reads a protocol definition from stdin, writes the generated mock class to stdout. Runs the exact `@Mockable` generation path (`MockableGenerator.processProtocol`) outside the compiler, so output is byte-identical to macro expansion (same `BasicFormat` normalization `assertMacroExpansion` applies), including the `#if DEBUG` wrapper.
- New `MockableGenerator.generateMocks(source:includeDebugWrapper:)` pipeline: parses with `SwiftParser`, throws annotated diagnostics on parse errors, honors `@Mockable` options from the input protocol, reports inherited type names per generated mock, and supports multiple top-level protocols per invocation (declaration order).
- `--no-debug-wrap` flag emits the mock bare — the right form for pasting into test targets, since `DEBUG` is defined per build configuration and a wrapped mock vanishes under `swift test -c release`. Default remains full parity with the macro.
- stdout only ever carries generated code; warnings (e.g. a protocol that inherits another protocol — inherited requirements are not implemented, mock won't conform) and errors go to stderr; exit status 0/1.
- Docs: README documents the release-binary install (`swift build -c release --product mockable`) and PATH copy; the bundled agent skill routes mock-source generation through the CLI, with hand-writing remaining a first-class fallback (required for inheritance, pinned-spy zero-arg members).

## Test plan

- [x] 9 new `GeneratorPipelineTests`: byte-exact parity with pinned macro-expansion fixtures (method + property shapes), unwrap behavior, option handling, multi-protocol ordering, inheritance reporting, no-protocol and malformed-input errors
- [x] Full suite: 180 tests, 0 failures (`swift test`)
- [x] CLI smoke: default output, `--no-debug-wrap`, inheritance warning on stderr, no-protocol and malformed input exit 1 with annotated diagnostics, `--help`
- [x] Generated mock for a protocol with `async throws`, `var { get set }`, and `static` member typechecked against the `SwiftMocking` module (`swiftc -typecheck -D DEBUG`)
- [ ] `pull_request.yml` workflow green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `mockable` command-line tool that generates mock implementations from Swift protocols.
  * Supports multiple protocols, optional debug wrappers, help output, diagnostics, and inherited-protocol warnings.
  * Provides clear failure messages for invalid input or missing protocols.

* **Documentation**
  * Added CLI usage, installation, troubleshooting, and manual mocking guidance.

* **Tests**
  * Added coverage for generation, protocol features, inheritance, formatting options, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->