### PR TITLE
Support subscript requirements in @Mockable

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -207,18 +207,7 @@ public extension MockableGenerator {
         let parameter = FunctionParameterSyntax(
             firstName: .identifier("newValue"),
             colon: .colonToken(trailingTrivia: .space),
-            type: TypeSyntax(
-                IdentifierTypeSyntax(
-                    name: .identifier("ArgMatcher"),
-                    genericArgumentClause: GenericArgumentClauseSyntax {
-                        #if canImport(SwiftSyntax601)
-                        GenericArgumentSyntax(argument: .init(type))
-                        #else
-                        GenericArgumentSyntax(argument: (type))
-                        #endif
-                    }
-                )
-            )
+            type: argMatcherType(type)
         )
         let parameterList = FunctionParameterListSyntax([parameter])
         let interactionReturnType = createInteractionReturnType(inputTypes: [type], outputType: TypeSyntax(stringLiteral: "Void"), effectType: .none, genericParameterClause: nil)
@@ -240,6 +229,22 @@ public extension MockableGenerator {
                 returnClause: interactionReturnType
             ),
             body: body
+        )
+    }
+
+    /// Wraps a type in `ArgMatcher<...>` for interaction parameter clauses.
+    private static func argMatcherType(_ type: TypeSyntax) -> TypeSyntax {
+        TypeSyntax(
+            IdentifierTypeSyntax(
+                name: .identifier("ArgMatcher"),
+                genericArgumentClause: GenericArgumentClauseSyntax {
+                    #if canImport(SwiftSyntax601)
+                    GenericArgumentSyntax(argument: .init(type))
+                    #else
+                    GenericArgumentSyntax(argument: (type))
+                    #endif
+                }
+            )
         )
     }
 

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -44,8 +44,7 @@ public extension MockableGenerator {
                 let stubFunctions = processVar(varDecl)
                 members.append(contentsOf: stubFunctions)
             } else if let subscriptDecl = member.decl.as(SubscriptDeclSyntax.self) {
-                let stubFunction = processSubscript(subscriptDecl)
-                members.append(stubFunction)
+                members.append(contentsOf: processSubscript(subscriptDecl))
             }
         }
 
@@ -115,15 +114,34 @@ public extension MockableGenerator {
         return decls
     }
 
-    /// Processes a subscript declaration to generate an interaction function.
+    /// Processes a subscript declaration to generate interaction declarations.
     ///
-    /// For a subscript `subscript(index: Int) -> String`, this will generate:
+    /// For a subscript `subscript(index: Int) -> String { get }`, this will generate:
     /// ```swift
     /// subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String> {
     ///     get { ... }
     /// }
     /// ```
-    private static func processSubscript(_ subscriptDecl: SubscriptDeclSyntax) -> DeclSyntax {
+    ///
+    /// If the subscript is settable, it also generates a setter interaction function
+    /// (see ``subscriptSetterInteraction(_:)``) that stubs and verifies writes.
+    private static func processSubscript(_ subscriptDecl: SubscriptDeclSyntax) -> [DeclSyntax] {
+        var decls = [DeclSyntax(subscriptGetterInteraction(subscriptDecl))]
+        if subscriptDecl.hasSetter {
+            decls.append(DeclSyntax(subscriptSetterInteraction(subscriptDecl)))
+        }
+        return decls
+    }
+
+    /// Creates a getter interaction subscript mirroring the requirement's indices.
+    ///
+    /// For a subscript `subscript(index: Int) -> String`, this will generate:
+    /// ```swift
+    /// subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String> {
+    ///     get { Interaction(index, spy: super.subscript) }
+    /// }
+    /// ```
+    private static func subscriptGetterInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
         let subscriptDecl = SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
@@ -148,13 +166,72 @@ public extension MockableGenerator {
                             ).statements
                         }
                     )
-                    //
-
                 })
             )
         )
 
-        return DeclSyntax(subscriptDecl)
+        return subscriptDecl
+    }
+
+    /// Creates a setter interaction function for a settable subscript.
+    ///
+    /// For a settable subscript `subscript(index: Int) -> String { get set }`, this will generate:
+    /// ```swift
+    /// func setSubscript(index: ArgMatcher<Int>, newValue: ArgMatcher<String>) -> Interaction<Int, String, None, Void> {
+    ///     Interaction(index, newValue, spy: super.setSubscript)
+    /// }
+    /// ```
+    ///
+    /// The written value is recorded as a trailing argument on the `setSubscript` spy,
+    /// mirroring how `setName(newValue:)` records property writes. Reads keep using
+    /// the `subscript` spy, so get and set verifications stay independent.
+    private static func subscriptSetterInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> FunctionDeclSyntax {
+        let outputType = subscriptDecl.returnClause.type
+        let setterName = TokenSyntax.identifier("setSubscript")
+
+        let parameterClause = FunctionParameterClauseSyntax(
+            parameters: FunctionParameterListSyntax {
+                for parameter in createArgMatcherParameters(subscriptDecl.parameterClause).parameters {
+                    parameter
+                }
+                FunctionParameterSyntax(
+                    firstName: .identifier("newValue"),
+                    colon: .colonToken(trailingTrivia: .space),
+                    type: argMatcherType(outputType)
+                )
+            }
+        )
+        let interactionReturnType = createInteractionReturnType(
+            inputTypes: subscriptDecl.parameterClause.parameters.map(\.type) + [outputType],
+            outputType: TypeSyntax(stringLiteral: "Void"),
+            effectType: .none,
+            genericParameterClause: subscriptDecl.genericParameterClause
+        )
+        let body = createFunctionBody(
+            spyPropertyName: setterName.text,
+            parameterNames: FunctionParameterListSyntax {
+                for parameter in subscriptDecl.parameterClause.parameters {
+                    parameter
+                }
+                FunctionParameterSyntax(
+                    firstName: .identifier("newValue"),
+                    colon: .colonToken(trailingTrivia: .space),
+                    type: outputType
+                )
+            }
+        )
+
+        return FunctionDeclSyntax(
+            modifiers: subscriptDecl.modifiers.trimmed,
+            name: setterName,
+            genericParameterClause: subscriptDecl.genericParameterClause,
+            signature: FunctionSignatureSyntax(
+                parameterClause: parameterClause,
+                returnClause: interactionReturnType
+            ),
+            genericWhereClause: subscriptDecl.genericWhereClause,
+            body: body
+        )
     }
 
     /// Creates a getter interaction function for a variable.

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -138,9 +138,12 @@ extension MockableGenerator {
     
     /// Generates a subscript declaration that fulfills a protocol requirement.
     ///
-    /// For a subscript `subscript(index: Int) -> String`, this will generate a subscript with a getter that calls the mock's `adapt` function.
+    /// For a subscript `subscript(index: Int) -> String { get }`, this will generate a subscript with a getter that calls the mock's `adapt` function.
+    /// For a settable requirement, it also generates a setter that records the write —
+    /// indices followed by `newValue` — on the `setSubscript` spy.
     static func subscriptRequirement(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
-        SubscriptDeclSyntax(
+        let parameterNames = subscriptDecl.parameterClause.parameters.map({ $0.secondName ?? $0.firstName })
+        return SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
             parameterClause: subscriptDecl.parameterClause,
@@ -149,6 +152,22 @@ extension MockableGenerator {
             accessorBlock: AccessorBlockSyntax(
                 accessors: .accessors(
                     AccessorDeclListSyntax {
+                        // Setter
+                        if subscriptDecl.hasSetter {
+                            AccessorDeclSyntax(
+                                accessorSpecifier: .keyword(.set),
+                                bodyBuilder: {
+                                    ReturnStmtSyntax(
+                                        expression: adaptCall(
+                                            effectType: .none,
+                                            requirementName: .identifier("setSubscript"),
+                                            parameters: parameterNames + [.identifier("newValue")]
+                                        )
+                                    )
+                                }
+                            )
+                        }
+                        // Getter
                         AccessorDeclSyntax(
                             accessorSpecifier: .keyword(.get),
                             bodyBuilder: {
@@ -156,7 +175,7 @@ extension MockableGenerator {
                                     expression: adaptCall(
                                         effectType: .none,
                                         requirementName: .identifier("subscript"),
-                                        parameters: subscriptDecl.parameterClause.parameters.map({ $0.secondName ?? $0.firstName })
+                                        parameters: parameterNames
                                     )
                                 )
                             }

--- a/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
+++ b/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
@@ -29,6 +29,13 @@ extension VariableDeclSyntax {
     }
 }
 
+extension SubscriptDeclSyntax {
+    /// A boolean value indicating whether the subscript has a setter.
+    var hasSetter: Bool {
+        accessorBlock?.accessors.hasSetter ?? false
+    }
+}
+
 extension AccessorBlockSyntax.Accessors {
   /// The list of accessors, if the accessor block is of the `.accessors` case.
   var settersAndGetters: AccessorDeclListSyntax? {

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -121,6 +121,44 @@ final class ProtocolFeaturesTests: MacroTestCase {
         }
     }
 
+    func testProtocolWithSettableSubscript() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol MyService {
+                subscript(index: Int) -> String { get set }
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                subscript(index: Int) -> String { get set }
+            }
+
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String > {
+                    get {
+                        Interaction(index, spy: super.subscript)
+                    }
+                }
+                func setSubscript(index: ArgMatcher<Int>, newValue: ArgMatcher<String >) -> Interaction<Int, String , None, Void> {
+                    Interaction(index, newValue, spy: super.setSubscript)
+                }
+                subscript(index: Int) -> String {
+                    set {
+                        return adapt(super.setSubscript, index, newValue)
+                    }
+                    get {
+                        return adapt(super.subscript, index)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
     func testProtocolWithAssociatedType() {
         assertMacro {
             """

--- a/Tests/SwiftMockingTests/SubscriptInteractionTests.swift
+++ b/Tests/SwiftMockingTests/SubscriptInteractionTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import SwiftMocking
+import SwiftMockingTestSupport
+
+@Mockable
+protocol SubscriptService {
+    subscript(index: Int) -> String { get }
+}
+
+@Mockable
+protocol SettableSubscriptService {
+    subscript(index: Int) -> String { get set }
+}
+
+/// End-to-end coverage for protocol subscript requirements.
+///
+/// The macro expansions are covered in `ProtocolFeaturesTests` (get-only and
+/// get-set); these tests exercise the generated mocks at runtime.
+///
+/// Reads stub and verify through the `ArgMatcher` interaction subscript
+/// (`mock[.any]`). Writes record on a separate `setSubscript` spy with the
+/// written value as a trailing argument, mirroring `setValue(newValue:)` for
+/// properties — reached via `mock.setSubscript(index:newValue:)`.
+final class SubscriptInteractionTests: MockingTestCase {
+    // MARK: Get
+
+    func testSubscriptGetter_StubbedValueIsReturned() {
+        let mock = MockSubscriptService()
+        when(mock[.any]).thenReturn("stubbed")
+
+        let result = mock[42]
+
+        XCTAssertEqual(result, "stubbed")
+    }
+
+    func testSubscriptGetter_StubbedValueRespectsArgumentMatcher() {
+        let mock = MockSubscriptService()
+        let service: SubscriptService = mock
+        when(mock[.equal(1)]).thenReturn("one")
+        when(mock[.equal(2)]).thenReturn("two")
+
+        XCTAssertEqual(service[1], "one")
+        XCTAssertEqual(service[2], "two")
+    }
+
+    func testSubscriptGetter_InvocationIsRecordedForVerification() {
+        let mock = MockSubscriptService()
+        let service: SubscriptService = mock
+
+        _ = service[1]
+        _ = service[2]
+        _ = service[2]
+
+        verify(mock[.equal(1)]).called(1)
+        verify(mock[.equal(2)]).called(2)
+        verify(mock[.any]).called(3)
+    }
+
+    func testSubscriptGetter_NeverCalledVerification() {
+        let mock = MockSubscriptService()
+
+        verifyNever(mock[.any])
+    }
+
+    // MARK: Set
+
+    func testSubscriptSetter_WriteIsRecordedForVerification() {
+        let mock = MockSettableSubscriptService()
+        var service: SettableSubscriptService = mock
+
+        service[0] = "written"
+
+        verify(mock.setSubscript(index: .any, newValue: .any)).called(1)
+    }
+
+    func testSubscriptSetter_VerificationRespectsArgumentMatchers() {
+        let mock = MockSettableSubscriptService()
+        var service: SettableSubscriptService = mock
+
+        service[1] = "one"
+        service[2] = "two"
+        service[2] = "two"
+
+        verify(mock.setSubscript(index: .equal(1), newValue: .equal("one"))).called(1)
+        verify(mock.setSubscript(index: .equal(2), newValue: .equal("two"))).called(2)
+        verify(mock.setSubscript(index: .any, newValue: .any)).called(3)
+    }
+
+    func testSubscriptSetter_NeverCalledVerification() {
+        let mock = MockSettableSubscriptService()
+
+        verifyNever(mock.setSubscript(index: .any, newValue: .any))
+    }
+
+    // MARK: Get and set are independent interactions
+
+    func testSubscript_GetAndSetAreRecordedOnSeparateSpies() {
+        let mock = MockSettableSubscriptService()
+        var service: SettableSubscriptService = mock
+
+        _ = service[1]
+        service[1] = "one"
+        service[2] = "two"
+
+        verify(mock[.any]).called(1)
+        verify(mock.setSubscript(index: .any, newValue: .any)).called(2)
+        verify(mock.setSubscript(index: .equal(1), newValue: .any)).called(1)
+    }
+
+    func testSettableSubscript_GetterStillStubbable() {
+        let mock = MockSettableSubscriptService()
+        let service: SettableSubscriptService = mock
+        when(mock[.any]).thenReturn("stubbed")
+
+        XCTAssertEqual(service[7], "stubbed")
+        verify(mock[.any]).called(1)
+    }
+}


### PR DESCRIPTION
First of a six-PR stack (#105) splitting the original #98.

Adds subscript support to `@Mockable`: get-only and get-set requirements generate an `ArgMatcher` interaction subscript alongside the conformance subscript, so `when(mock[.any])` and `verify(mock[.equal(1)])` work.

Settable subscripts use the `setSubscript(...)` shape at this point — the migration to `SettableInteraction` comes in #101.

Also extracts `ArgMatcher` type construction into a helper, reused by the later expansion work.

**Tests:** 190 pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mocking protocols with settable subscripts.
  * Generated APIs now support stubbing and verifying both subscript reads and writes.
  * Setter interactions record subscript indices and assigned values independently.

* **Bug Fixes**
  * Improved handling of subscript accessors and argument matching for variable setters.

* **Tests**
  * Added coverage for getter/setter forwarding, matching, invocation verification, and `verifyNever` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->