### PR TITLE
Add SettableInteraction runtime API

### DIFF
--- a/Sources/SwiftMocking/Interaction.swift
+++ b/Sources/SwiftMocking/Interaction.swift
@@ -7,14 +7,14 @@
 
 /// Represents a specific interaction with a mock object, combining an ``InvocationMatcher`` and a ``Spy``.
 ///
-/// This struct is primarily used internally by the Mockable framework and in conjunction with the ``when(_:)`` and ``verify(_:)`` functions
+/// This struct is primarily used internally by the Mockable framework and in conjunction with the ``when(_:)-1t69o`` and ``verify(_:)-2pseu`` functions
 /// to define stubbing behavior or verify method calls.
 ///
 /// ## Usage
 /// Interactions are typically created by generated mock methods and used with:
-/// - ``when(_:)`` - For stubbing method behavior
-/// - ``verify(_:)`` - For verifying method calls
-/// - ``verifyNever(_:file:line:)`` - For ensuring methods were not called
+/// - ``when(_:)-1t69o`` - For stubbing method behavior
+/// - ``verify(_:)-2pseu`` - For verifying method calls
+/// - ``verifyNever(_:file:line:)-14uw9`` - For ensuring methods were not called
 ///
 /// ## Related Types
 /// - ``Spy`` - The spy that records invocations for this interaction

--- a/Sources/SwiftMocking/SettableInteraction.swift
+++ b/Sources/SwiftMocking/SettableInteraction.swift
@@ -1,0 +1,68 @@
+//
+//  SettableInteraction.swift
+//  swift-mocking
+//
+//  Created by Daniel Cardona on 20/08/25.
+//
+
+import Foundation
+
+/// A read/write interaction surface for a settable requirement.
+///
+/// Settable members record reads and writes on two distinct spies — their input
+/// packs differ (`(indices…)` for reads, `(indices…, newValue)` for writes) — so
+/// a single ``Interaction`` cannot address both. Generated mocks for settable
+/// requirements return this wrapper instead, carrying both bindings:
+/// ``get`` addresses reads, and ``set(_:)`` addresses writes.
+///
+/// `Input` is the read pack: the index pack for a subscript requirement, or
+/// `(Void)` for a variable requirement. `Output` is the element type. The write
+/// pack is always the read pack plus the written value.
+///
+/// ## Usage
+/// ```swift
+/// when(mock[.any]).thenReturn("stubbed")             // stub reads
+/// verify(mock[.equal(1)] <- "one").called(1)         // verify writes
+/// when(mock.value <- 7).thenReturn { _, new in … }   // write side effects
+/// verifyInOrder([mock[.any] <- "one"])               // composes
+/// ```
+public struct SettableInteraction<each Input, Eff: Effect, Output> {
+    /// The read interaction — records on the requirement's getter spy.
+    public let get: Interaction<repeat each Input, Eff, Output>
+
+    /// Builds the write interaction for a matched value.
+    ///
+    /// Injected by generated code because appending a value after a pack
+    /// expansion (`(repeat each Input, Output)`) is not expressible in a
+    /// generic body on this toolchain.
+    private let setInteraction: @Sendable (ArgMatcher<Output>) -> Interaction<repeat each Input, Output, None, Void>
+
+    /// Initializes a `SettableInteraction` with both directions' bindings.
+    ///
+    /// - Parameters:
+    ///   - get: The interaction for reads.
+    ///   - setInteraction: Builds the write interaction for an assigned-value
+    ///     matcher; the generated implementation records on the write spy with
+    ///     the read matchers followed by the value matcher.
+    public init(
+        get: Interaction<repeat each Input, Eff, Output>,
+        setInteraction: @escaping @Sendable (ArgMatcher<Output>) -> Interaction<repeat each Input, Output, None, Void>
+    ) {
+        self.get = get
+        self.setInteraction = setInteraction
+    }
+
+    /// Returns the write interaction for a matched value.
+    ///
+    /// The result is a plain ``Interaction`` recording on the write spy with
+    /// the read pack's matchers followed by `newValue`, so it composes with
+    /// `verifyInOrder`, `captured`, and `until` unchanged.
+    ///
+    /// - Parameter newValue: Matcher for the assigned value.
+    /// - Returns: The write interaction.
+    public func set(_ newValue: ArgMatcher<Output>) -> Interaction<repeat each Input, Output, None, Void> {
+        setInteraction(newValue)
+    }
+}
+
+extension SettableInteraction: Sendable where repeat each Input: Sendable, Output: Sendable { }

--- a/Sources/SwiftMocking/SwiftMocking.docc/SwiftMocking.md
+++ b/Sources/SwiftMocking/SwiftMocking.docc/SwiftMocking.md
@@ -6,7 +6,7 @@ Type-safe mocking for Swift, powered by macros.
 
 SwiftMocking turns any protocol into a fully featured mock with a single
 `@Mockable` annotation. Describe calls with matchers, arrange behavior with
-``when(_:)``, assert interactions with ``verify(_:)`` — all statically typed,
+``when(_:)-1t69o``, assert interactions with ``verify(_:)-2pseu`` — all statically typed,
 all local, with no code-generation step in your build.
 
 ```swift
@@ -35,8 +35,8 @@ verification. Start with
 ### Essentials
 
 - ``Mock``
-- ``when(_:)``
-- ``verify(_:)``
+- ``when(_:)-1t69o``
+- ``verify(_:)-2pseu``
 - ``ArgMatcher``
 
 ### Stubbing
@@ -45,8 +45,18 @@ verification. Start with
 - ``Spy``
 - ``Stub``
 
+### Settable Requirements
+
+Settable properties and subscripts (`{ get set }`) record reads and writes on
+separate spies. Their interaction member returns a ``SettableInteraction``,
+which addresses reads directly and writes through the `<-` operator.
+
+- ``SettableInteraction``
+- ``<-(_:_:)-kz9a``
+- ``<-(_:_:)-67g91``
+
 ### Verification
 
 - ``verifyInOrder(_:file:line:)-7ca0p``
-- ``verifyNever(_:file:line:)``
+- ``verifyNever(_:file:line:)-14uw9``
 - ``verifyZeroInteractions(_:file:line:)``

--- a/Sources/SwiftMocking/TestSupport.swift
+++ b/Sources/SwiftMocking/TestSupport.swift
@@ -41,6 +41,28 @@ public func when<each Input, Eff: Effect, Output>(_ interaction: (()) -> Interac
     return interaction.spy.when(calledWith: interaction.invocationMatcher)
 }
 
+/// Configures a stub for the reads of a settable requirement.
+///
+/// ```swift
+/// when(mock[.any]).thenReturn("mocked_value")
+/// ```
+public func when<each Input, Eff: Effect, Output>(
+    _ interaction: SettableInteraction<repeat each Input, Eff, Output>
+) -> Arrange<repeat each Input, Eff, Output> {
+    when(interaction.get)
+}
+
+/// Configures a stub for the reads of a settable variable, accepting an
+/// unapplied reference to its interaction member:
+/// ```swift
+/// when(mock.value).thenReturn("mocked_value")
+/// ```
+public func when<each Input, Eff: Effect, Output>(
+    _ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>
+) -> Arrange<repeat each Input, Eff, Output> {
+    when(interaction(()).get)
+}
+
 /// Verifies that a specific interaction with a mock object has occurred.
 ///
 /// This function is used to assert that a mocked method was called with arguments
@@ -74,6 +96,21 @@ public func verify<each Input, Eff: Effect, Output>(
 ) -> Assert<repeat each Input, Eff, Output> {
     let interaction = interaction(())
     return Assert(invocationMatcher: interaction.invocationMatcher, spy: interaction.spy)
+}
+
+/// Verifies the reads of a settable requirement.
+public func verify<each Input, Eff: Effect, Output>(
+    _ interaction: SettableInteraction<repeat each Input, Eff, Output>
+) -> Assert<repeat each Input, Eff, Output> {
+    verify(interaction.get)
+}
+
+/// Verifies the reads of a settable variable, accepting an unapplied
+/// reference to its interaction member: `verify(mock.value).called(1)`.
+public func verify<each Input, Eff: Effect, Output>(
+    _ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>
+) -> Assert<repeat each Input, Eff, Output> {
+    verify(interaction(()).get)
 }
 
 /// Verifies that a sequence of interactions across multiple mock objects occurred in the specified order.
@@ -161,6 +198,61 @@ public func verifyNever<each Input, Eff: Effect, Output>(
     line: UInt = #line
 ) {
     verify(interaction).neverCalled(file: file, line: line)
+}
+
+/// Verifies that a settable requirement was never read.
+public func verifyNever<each Input, Eff: Effect, Output>(
+    _ interaction: SettableInteraction<repeat each Input, Eff, Output>,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    verify(interaction.get).neverCalled(file: file, line: line)
+}
+
+/// Verifies that a settable variable was never read, accepting an unapplied
+/// reference to its interaction member: `verifyNever(mock.value)`.
+public func verifyNever<each Input, Eff: Effect, Output>(
+    _ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    verify(interaction(()).get).neverCalled(file: file, line: line)
+}
+
+infix operator <- : AssignmentPrecedence
+
+
+/// Builds the write interaction for a settable requirement.
+///
+/// The result is a plain ``Interaction``, so `when`, `verify`, `verifyNever`,
+/// and `verifyInOrder` consume writes through their existing overloads:
+/// ```swift
+/// verify(mock[.equal(2)] <- "two").called(1)
+/// when(mock.value <- 7).thenReturn { _, newValue in … }
+/// verifyNever(mock[.any] <- "deleted")
+/// ```
+///
+/// The result is deliberately not `@discardableResult`: this operator only
+/// *builds* an interaction, it records nothing. A bare `mock.value <- 7`
+/// statement looks like it performs a write but is a no-op, so the unused-result
+/// warning is what surfaces that mistake. To perform an actual write, assign to
+/// the requirement (`mock.value = 7`).
+public func <- <each Input, Eff: Effect, Output>(
+    _ interaction: SettableInteraction<repeat each Input, Eff, Output>,
+    _ newValue: ArgMatcher<Output>
+) -> Interaction<repeat each Input, Output, None, Void> {
+    interaction.set(newValue)
+}
+
+/// Builds the write interaction for a settable variable, accepting an
+/// unapplied reference to its interaction member: `mock.value <- 7`.
+///
+/// Not `@discardableResult`, for the reason given on the overload above.
+public func <- <each Input, Eff: Effect, Output>(
+    _ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>,
+    _ newValue: ArgMatcher<Output>
+) -> Interaction<repeat each Input, Output, None, Void> {
+    interaction(()).set(newValue)
 }
 
 /// Verifies that a mock object has had zero interactions.

--- a/Sources/SwiftMockingTestSupport/CaptureBox.swift
+++ b/Sources/SwiftMockingTestSupport/CaptureBox.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A thread-safe collector for values observed inside a stub's handler closure.
+///
+/// Stub handlers are `@Sendable`, so a test cannot append to a local `var` from
+/// inside one. ``CaptureBox`` gives that recording a home whose mutation is
+/// lock-guarded, letting a test assert on what a stub actually received:
+///
+/// ```swift
+/// let written = CaptureBox<Int>()
+/// when(mock.value <- 7).thenReturn { _, newValue in
+///     written.append(newValue)
+/// }
+/// mock.value = 7
+/// XCTAssertEqual(written.values, [7])
+/// ```
+///
+/// Prefer `verify(...).captured { ... }` when the assertion is about recorded
+/// invocations; reach for a `CaptureBox` when what matters is that a *stub
+/// handler ran* — with the values it was handed, in order.
+public final class CaptureBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Value] = []
+
+    /// Creates an empty box.
+    public init() {}
+
+    /// Appends a value observed inside a handler closure.
+    public func append(_ value: Value) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.append(value)
+    }
+
+    /// The values appended so far, in order.
+    public var values: [Value] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}

--- a/Tests/SwiftMockingTests/SettableInteractionAPITests.swift
+++ b/Tests/SwiftMockingTests/SettableInteractionAPITests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import SwiftMocking
+import SwiftMockingTestSupport
+
+/// Exercises `SettableInteraction` and `<-` directly, without the macro.
+///
+/// The generator does not emit `SettableInteraction` yet; this pins the runtime
+/// contract the subscript and variable expansions will target — reads and writes
+/// land on separate spies, and the write pack is the read pack plus the value.
+private final class ManualSettableMock: Mock, @unchecked Sendable {
+    // Runtime members, written the way the generator will emit them.
+    var value: Int {
+        get { adapt(super.value, ()) }
+        set { return adapt(super.setValue, (), newValue) }
+    }
+
+    subscript(index: Int) -> String {
+        get { return adapt(super.subscriptIndex, index) }
+        set { return adapt(super.setSubscriptIndex, index, newValue) }
+    }
+
+    // Interaction members.
+    func value(_ void: Void) -> SettableInteraction<Void, None, Int> {
+        SettableInteraction(
+            get: Interaction(.any, spy: super.value),
+            setInteraction: { newValue in
+                Interaction(.any, newValue, spy: super.setValue)
+            }
+        )
+    }
+
+    subscript(index: ArgMatcher<Int>) -> SettableInteraction<Int, None, String> {
+        get {
+            SettableInteraction(
+                get: Interaction(index, spy: super.subscriptIndex),
+                setInteraction: { newValue in
+                    Interaction(index, newValue, spy: super.setSubscriptIndex)
+                }
+            )
+        }
+    }
+}
+
+final class SettableInteractionAPITests: MockingTestCase {
+    func testVariableReadsAndWritesUseSeparateSpies() {
+        let mock = ManualSettableMock()
+        when(mock.value).thenReturn(7)
+
+        XCTAssertEqual(mock.value, 7)
+        mock.value = 9
+
+        verify(mock.value).called(1)
+        verify(mock.value <- 9).called(1)
+        verifyNever(mock.value <- 7)
+    }
+
+    func testSubscriptReadsAndWritesUseSeparateSpies() {
+        let mock = ManualSettableMock()
+        when(mock[.any]).thenReturn("read")
+
+        XCTAssertEqual(mock[1], "read")
+        mock[1] = "written"
+
+        verify(mock[.equal(1)]).called(1)
+        verify(mock[.equal(1)] <- "written").called(1)
+        verifyNever(mock[.equal(2)] <- .any)
+    }
+
+    func testWritePackIsReadPackPlusValue() {
+        let mock = ManualSettableMock()
+
+        mock[3] = "written"
+
+        verify(mock[.any] <- .any).captured { index, newValue in
+            XCTAssertEqual(index, 3)
+            XCTAssertEqual(newValue, "written")
+        }
+    }
+
+    func testWriteSideEffectRunsThroughCaptureBox() {
+        let mock = ManualSettableMock()
+        let written = CaptureBox<Int>()
+        when(mock.value <- 7).thenReturn { _, newValue in
+            written.append(newValue)
+        }
+
+        mock.value = 7
+        mock.value = 8
+
+        XCTAssertEqual(written.values, [7])
+    }
+
+    func testWritesComposeWithVerifyInOrder() {
+        let mock = ManualSettableMock()
+
+        mock.value = 1
+        mock[2] = "two"
+
+        verifyInOrder([
+            mock.value <- 1,
+            mock[.equal(2)] <- "two"
+        ])
+    }
+}


### PR DESCRIPTION
Second of a six-PR stack (#105). Based on #99.

Adds the `SettableInteraction` runtime type and the `<-` operator — **no generator changes**, so this lands independently of the expansion work.

Settable requirements record reads and writes on two different spies, because their input packs differ: reads take the indices (or `(Void)` for a variable), writes take the indices plus the written value. A single `Interaction` cannot address both. `SettableInteraction` carries both bindings, and `<-` turns it into a plain write `Interaction`, so `when`/`verify`/`verifyNever`/`verifyInOrder` consume writes through their existing overloads unchanged.

The set builder is an injected closure: appending a value after a pack expansion isn't expressible in a generic body on this toolchain.

`<-` is deliberately **not** `@discardableResult` — it only builds an interaction, so a bare `mock.value <- 7` statement is a no-op that reads like a write. The unused-result warning surfaces that.

Also adds `CaptureBox` to `SwiftMockingTestSupport` for observing values inside `@Sendable` stub handlers.

**Tests:** 195 pass. `SettableInteractionAPITests` pins the contract against a hand-written mock shaped the way the generator will emit, so this isn't unused code.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mocking and verifying settable properties and subscripts, including separate read and write interactions.
  - Added write stubbing with argument matchers using the `<-` operator.
  - Added a thread-safe value capture utility for test support.

- **Documentation**
  - Added guidance for settable requirements and updated API links.

- **Tests**
  - Added coverage for settable reads, writes, matching, captures, and ordered verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->