### PR TITLE
Emit SettableInteraction for settable subscripts

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -212,6 +212,11 @@ public extension MockableGenerator {
                                     inputTypes: subscriptDecl.parameterClause.parameters
                                         .map { removeAttributes($0.type) },
                                     outputType: subscriptDecl.returnClause.type
+                                ),
+                                writeInteractionType: writeInteractionType(
+                                    inputTypes: subscriptDecl.parameterClause.parameters
+                                        .map { removeAttributes($0.type) },
+                                    outputType: subscriptDecl.returnClause.type
                                 )
                             ).statements
                         }
@@ -289,11 +294,14 @@ public extension MockableGenerator {
     /// the read's `(Void)` pack, matching `createFunctionBody`.
     /// - Parameter writeSpyType: The write spy's fully spelled type, used to
     ///   anchor inference inside the set closure.
+    /// - Parameter writeInteractionType: The write interaction's fully spelled
+    ///   type, used to anchor the returned value's pack.
     private static func createSettableFunctionBody(
         getterSpyName: String,
         setterSpyName: String,
         parameterNames: FunctionParameterListSyntax,
-        writeSpyType: TypeSyntax
+        writeSpyType: TypeSyntax,
+        writeInteractionType: TypeSyntax
     ) -> CodeBlockSyntax {
         // Relative to the statement's own column: SwiftSyntax supplies the
         // enclosing context's indentation when the body is placed, so these
@@ -310,7 +318,8 @@ public extension MockableGenerator {
             newValueName: "newValue",
             spyIsLocalBinding: true
         )
-        // Bind the write spy to an explicitly typed local first.
+        // Bind both the write spy and the resulting interaction to explicitly
+        // typed locals.
         //
         // `super.<spy>` is a generic @dynamicMemberLookup subscript and
         // `Interaction.init` is generic over Eff/Output, so with two or more
@@ -318,7 +327,22 @@ public extension MockableGenerator {
         // contextual result type is not enough to recover them:
         //   error: generic parameter 'Eff' could not be inferred
         // Swift 6.3 happens to solve it; 5.9 and 6.0 (both on CI) do not.
-        // Spelling the spy's type removes the ambiguity on every toolchain.
+        // Spelling the spy's type removes that ambiguity.
+        //
+        // The interaction needs the same treatment for a further reason. Its
+        // declared result pack is `(repeat each Input, Output)`, so returning
+        // `Interaction(row, column, newValue, spy:)` directly asks the solver to
+        // split a concrete `Int, Int, String` back into a two-element `each
+        // Input` plus `Output`. Pack suffix splitting is not inferable: 5.9/6.0
+        // bind `each Input` to a single unsolved element and fail with
+        //   error: pack expansion requires that '_' and 'Int, Int' have the
+        //          same shape
+        //   error: cannot convert value of type 'Interaction<_, String, None,
+        //          Void>' to closure result type 'Interaction<Int, Int, String,
+        //          None, Void>'
+        // Spelling the interaction's type states the pack instead of deriving
+        // it. Single-index subscripts and variables never hit this, since a
+        // one-element pack has only one possible split.
         let spyBinding = VariableDeclSyntax(
             bindingSpecifier: .keyword(.let),
             bindings: PatternBindingListSyntax {
@@ -338,7 +362,23 @@ public extension MockableGenerator {
                 )
             }
         )
-        // { newValue in\n<indent+2>let spy: …\n<indent+2>return Interaction(…)\n<indent+1>}
+        let interactionBinding = VariableDeclSyntax(
+            bindingSpecifier: .keyword(.let),
+            bindings: PatternBindingListSyntax {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier(writeInteractionBindingName)),
+                    typeAnnotation: TypeAnnotationSyntax(
+                        colon: .colonToken(trailingTrivia: .space),
+                        type: writeInteractionType
+                    ),
+                    initializer: InitializerClauseSyntax(
+                        equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space),
+                        value: setterCall
+                    )
+                )
+            }
+        )
+        // { newValue in\n<indent+2>let writeSpy: …\n<indent+2>let interaction: …\n<indent+2>return interaction\n<indent+1>}
         let setClosure = ClosureExprSyntax(
             leftBrace: .leftBraceToken(),
             signature: ClosureSignatureSyntax(
@@ -354,9 +394,15 @@ public extension MockableGenerator {
                 ),
                 CodeBlockItemSyntax(
                     leadingTrivia: .newline + indent(2),
+                    item: .decl(DeclSyntax(interactionBinding))
+                ),
+                CodeBlockItemSyntax(
+                    leadingTrivia: .newline + indent(2),
                     item: .stmt(StmtSyntax(ReturnStmtSyntax(
                         returnKeyword: .keyword(.return, trailingTrivia: .space),
-                        expression: ExprSyntax(setterCall)
+                        expression: ExprSyntax(DeclReferenceExprSyntax(
+                            baseName: .identifier(writeInteractionBindingName)
+                        ))
                     )))
                 )
             ]),
@@ -506,6 +552,10 @@ public extension MockableGenerator {
                 parameterNames: FunctionParameterListSyntax([]),
                 // A variable's read pack is (Void), so the write pack is (Void, T).
                 writeSpyType: writeSpyType(
+                    inputTypes: [TypeSyntax(stringLiteral: "Void")],
+                    outputType: type
+                ),
+                writeInteractionType: writeInteractionType(
                     inputTypes: [TypeSyntax(stringLiteral: "Void")],
                     outputType: type
                 )
@@ -807,6 +857,9 @@ public extension MockableGenerator {
     /// The local constant generated set closures bind the write spy to.
     static let writeSpyBindingName = "writeSpy"
 
+    /// The local constant generated set closures bind the write interaction to.
+    static let writeInteractionBindingName = "writeInteraction"
+
     /// Spells the write spy's type: `Spy<indices…, Output, None, Void>`.
     ///
     /// The write pack is the read pack plus the written value, and writes are
@@ -815,5 +868,14 @@ public extension MockableGenerator {
         let arguments = inputTypes.map(\.trimmedDescription)
             + [outputType.trimmedDescription, "None", "Void"]
         return TypeSyntax(stringLiteral: "Spy<\(arguments.joined(separator: ", "))>")
+    }
+
+    /// Spells the write interaction's type: `Interaction<indices…, Output, None, Void>`.
+    ///
+    /// Mirrors ``writeSpyType`` — same pack, different generic.
+    static func writeInteractionType(inputTypes: [TypeSyntax], outputType: TypeSyntax) -> TypeSyntax {
+        let arguments = inputTypes.map(\.trimmedDescription)
+            + [outputType.trimmedDescription, "None", "Void"]
+        return TypeSyntax(stringLiteral: "Interaction<\(arguments.joined(separator: ", "))>")
     }
 }

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -34,11 +34,10 @@ public extension MockableGenerator {
     /// ```
     static func makeInteractions(protocolDecl: ProtocolDeclSyntax) -> [DeclSyntax] {
         var members = [DeclSyntax]()
-        var functionNames = [String: Int]()
 
         for member in protocolDecl.memberBlock.members {
             if let funcDecl = member.decl.as(FunctionDeclSyntax.self) {
-                let stubFunction = processFunc(funcDecl, &functionNames)
+                let stubFunction = processFunc(funcDecl)
                 members.append(stubFunction)
             } else if let varDecl = member.decl.as(VariableDeclSyntax.self) {
                 let stubFunctions = processVar(varDecl)
@@ -59,7 +58,7 @@ public extension MockableGenerator {
     ///     Interaction(value, spy: super.doSomething)
     /// }
     /// ```
-    private static func processFunc(_ funcDecl: FunctionDeclSyntax, _ functionNames: inout [String: Int]) -> DeclSyntax {
+    private static func processFunc(_ funcDecl: FunctionDeclSyntax) -> DeclSyntax {
         let funcName = funcDecl.name.text
         let spyPropertyName = funcDecl.name.text
 
@@ -114,23 +113,16 @@ public extension MockableGenerator {
         return decls
     }
 
-    /// Processes a subscript declaration to generate interaction declarations.
+    /// Processes a subscript declaration to generate the interaction declaration.
     ///
-    /// For a subscript `subscript(index: Int) -> String { get }`, this will generate:
-    /// ```swift
-    /// subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String> {
-    ///     get { ... }
-    /// }
-    /// ```
-    ///
-    /// If the subscript is settable, it also generates a setter interaction function
-    /// (see ``subscriptSetterInteraction(_:)``) that stubs and verifies writes.
+    /// Get-only requirements generate an `Interaction` subscript; settable
+    /// requirements generate a `SettableInteraction` subscript exposing reads
+    /// (`when`/`verify`) and writes (`assigned:`) through one surface.
     private static func processSubscript(_ subscriptDecl: SubscriptDeclSyntax) -> [DeclSyntax] {
-        var decls = [DeclSyntax(subscriptGetterInteraction(subscriptDecl))]
         if subscriptDecl.hasSetter {
-            decls.append(DeclSyntax(subscriptSetterInteraction(subscriptDecl)))
+            return [DeclSyntax(subscriptSettableInteraction(subscriptDecl))]
         }
-        return decls
+        return [DeclSyntax(subscriptGetterInteraction(subscriptDecl))]
     }
 
     /// Creates a getter interaction subscript mirroring the requirement's indices.
@@ -138,13 +130,14 @@ public extension MockableGenerator {
     /// For a subscript `subscript(index: Int) -> String`, this will generate:
     /// ```swift
     /// subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String> {
-    ///     get { Interaction(index, spy: super.subscript) }
+    ///     get { Interaction(index, spy: super.index) }
     /// }
     /// ```
     private static func subscriptGetterInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
         let subscriptDecl = SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
+            genericParameterClause: subscriptDecl.genericParameterClause,
             parameterClause: createArgMatcherParameters(
                 subscriptDecl.parameterClause
             ),
@@ -154,6 +147,7 @@ public extension MockableGenerator {
                 effectType: .none,
                 genericParameterClause: subscriptDecl.genericParameterClause
             ),
+            genericWhereClause: subscriptDecl.genericWhereClause,
             accessorBlock: AccessorBlockSyntax(
                 accessors: .accessors(AccessorDeclListSyntax {
                     // Get
@@ -161,7 +155,7 @@ public extension MockableGenerator {
                         accessorSpecifier: .keyword(.get),
                         bodyBuilder: {
                             createFunctionBody(
-                                spyPropertyName: "subscript",
+                                spyPropertyName: subscriptDecl.name,
                                 parameterNames: subscriptDecl.parameterClause.parameters
                             ).statements
                         }
@@ -173,65 +167,224 @@ public extension MockableGenerator {
         return subscriptDecl
     }
 
-    /// Creates a setter interaction function for a settable subscript.
+    /// Creates a settable interaction subscript exposing both directions.
     ///
     /// For a settable subscript `subscript(index: Int) -> String { get set }`, this will generate:
     /// ```swift
-    /// func setSubscript(index: ArgMatcher<Int>, newValue: ArgMatcher<String>) -> Interaction<Int, String, None, Void> {
-    ///     Interaction(index, newValue, spy: super.setSubscript)
+    /// subscript(index: ArgMatcher<Int>) -> SettableInteraction<Int, String> {
+    ///     get {
+    ///         SettableInteraction(
+    ///             get: Interaction(index, spy: super.index),
+    ///             setInteraction: { newValue in
+    ///                 Interaction(index, newValue, spy: super.setIndex)
+    ///             }
+    ///         )
+    ///     }
     /// }
     /// ```
     ///
-    /// The written value is recorded as a trailing argument on the `setSubscript` spy,
-    /// mirroring how `setName(newValue:)` records property writes. Reads keep using
-    /// the `subscript` spy, so get and set verifications stay independent.
-    private static func subscriptSetterInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> FunctionDeclSyntax {
-        let outputType = subscriptDecl.returnClause.type
-        let setterName = TokenSyntax.identifier("setSubscript")
-
-        let parameterClause = FunctionParameterClauseSyntax(
-            parameters: FunctionParameterListSyntax {
-                for parameter in createArgMatcherParameters(subscriptDecl.parameterClause).parameters {
-                    parameter
-                }
-                FunctionParameterSyntax(
-                    firstName: .identifier("newValue"),
-                    colon: .colonToken(trailingTrivia: .space),
-                    type: argMatcherType(outputType)
-                )
-            }
-        )
-        let interactionReturnType = createInteractionReturnType(
-            inputTypes: subscriptDecl.parameterClause.parameters.map(\.type) + [outputType],
-            outputType: TypeSyntax(stringLiteral: "Void"),
-            effectType: .none,
-            genericParameterClause: subscriptDecl.genericParameterClause
-        )
-        let body = createFunctionBody(
-            spyPropertyName: setterName.text,
-            parameterNames: FunctionParameterListSyntax {
-                for parameter in subscriptDecl.parameterClause.parameters {
-                    parameter
-                }
-                FunctionParameterSyntax(
-                    firstName: .identifier("newValue"),
-                    colon: .colonToken(trailingTrivia: .space),
-                    type: outputType
-                )
-            }
-        )
-
-        return FunctionDeclSyntax(
-            modifiers: subscriptDecl.modifiers.trimmed,
-            name: setterName,
+    /// Reads record on the `subscript` spy, writes on the `setSubscript` spy with
+    /// the written value as a trailing argument.
+    private static func subscriptSettableInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
+        SubscriptDeclSyntax(
+            attributes: subscriptDecl.attributes,
+            modifiers: subscriptDecl.modifiers,
             genericParameterClause: subscriptDecl.genericParameterClause,
-            signature: FunctionSignatureSyntax(
-                parameterClause: parameterClause,
-                returnClause: interactionReturnType
+            parameterClause: createArgMatcherParameters(
+                subscriptDecl.parameterClause
+            ),
+            returnClause: createSettableInteractionReturnType(
+                inputTypes: subscriptDecl.parameterClause.parameters.map(\.type),
+                outputType: subscriptDecl.returnClause.type,
+                effectType: .none
             ),
             genericWhereClause: subscriptDecl.genericWhereClause,
-            body: body
+            accessorBlock: AccessorBlockSyntax(
+                accessors: .accessors(AccessorDeclListSyntax {
+                    AccessorDeclSyntax(
+                        accessorSpecifier: .keyword(.get),
+                        bodyBuilder: {
+                            createSettableFunctionBody(
+                                getterSpyName: subscriptDecl.name,
+                                setterSpyName: subscriptDecl.name.setterSpyName,
+                                parameterNames: subscriptDecl.parameterClause.parameters,
+                                writeSpyType: writeSpyType(
+                                    inputTypes: subscriptDecl.parameterClause.parameters
+                                        .map { removeAttributes($0.type) },
+                                    outputType: subscriptDecl.returnClause.type
+                                )
+                            ).statements
+                        }
+                    )
+                })
+            )
         )
+    }
+
+    /// Creates a return type for a settable interaction subscript.
+    ///
+    /// For input types `[Int]`, output type `String`, and effect `None`, this will generate:
+    /// ```swift
+    /// -> SettableInteraction<Int, None, String>
+    /// ```
+    private static func createSettableInteractionReturnType(inputTypes: [TypeSyntax], outputType: TypeSyntax, effectType: EffectType) -> ReturnClauseSyntax {
+        var genericArgs = [GenericArgumentSyntax]()
+        for inputType in inputTypes {
+            #if canImport(SwiftSyntax601)
+            genericArgs.append(GenericArgumentSyntax(argument: .init(removeAttributes(inputType))))
+            #else
+            genericArgs.append(GenericArgumentSyntax(argument: removeAttributes(inputType)))
+            #endif
+        }
+        #if canImport(SwiftSyntax601)
+        genericArgs.append(GenericArgumentSyntax(argument: .init(TypeSyntax(stringLiteral: effectType.rawValue))))
+        genericArgs.append(GenericArgumentSyntax(argument: .init(outputType)))
+        #else
+        genericArgs.append(GenericArgumentSyntax(argument: TypeSyntax(stringLiteral: effectType.rawValue)))
+        genericArgs.append(GenericArgumentSyntax(argument: outputType))
+        #endif
+
+        let genericStubType = IdentifierTypeSyntax(
+            name: .identifier("SettableInteraction"),
+            genericArgumentClause: GenericArgumentClauseSyntax(
+                leftAngle: .leftAngleToken(),
+                arguments: GenericArgumentListSyntax(
+                    genericArgs.enumerated().map { (index, arg) in
+                        GenericArgumentSyntax(
+                            argument: arg.argument,
+                            trailingComma: index == genericArgs.count - 1 ? nil : .commaToken()
+                        )
+                    }
+                ),
+                rightAngle: .rightAngleToken()
+            )
+        )
+
+        return ReturnClauseSyntax(
+            arrow: .arrowToken(leadingTrivia: .space, trailingTrivia: .space),
+            type: TypeSyntax(genericStubType)
+        )
+    }
+
+    /// Creates the body of a settable interaction member, wiring both spies.
+    ///
+    /// For `getterSpyName: "index"`, `setterSpyName: "setIndex"` and
+    /// parameters `[index]`, this will generate:
+    /// ```swift
+    /// SettableInteraction(
+    ///     get: Interaction(index, spy: super.index),
+    ///     setInteraction: { newValue in
+    ///         Interaction(index, newValue, spy: super.setIndex)
+    ///     }
+    /// )
+    /// ```
+    ///
+    /// Each argument goes on its own line with explicit trivia: the expansion is
+    /// user-facing (it appears in macro-expansion diffs and generated sources),
+    /// and SwiftSyntax does not re-indent nested nodes on its own — without this
+    /// the call collapses onto one line and the closure body drifts rightward.
+    ///
+    /// `newValue` is appended after the read arguments so the write pack is the
+    /// read pack plus the written value. Empty parameter lists pass `.any` for
+    /// the read's `(Void)` pack, matching `createFunctionBody`.
+    /// - Parameter writeSpyType: The write spy's fully spelled type, used to
+    ///   anchor inference inside the set closure.
+    private static func createSettableFunctionBody(
+        getterSpyName: String,
+        setterSpyName: String,
+        parameterNames: FunctionParameterListSyntax,
+        writeSpyType: TypeSyntax
+    ) -> CodeBlockSyntax {
+        // Relative to the statement's own column: SwiftSyntax supplies the
+        // enclosing context's indentation when the body is placed, so these
+        // offsets must not restate it. That keeps one builder correct at both
+        // nesting depths — a variable's function body and a subscript's `get`.
+        let indent = { (level: Int) in Trivia.spaces(4 * level) }
+        let getterCall = interactionCall(
+            spyPropertyName: getterSpyName,
+            parameterNames: parameterNames
+        )
+        let setterCall = interactionCall(
+            spyPropertyName: writeSpyBindingName,
+            parameterNames: parameterNames,
+            newValueName: "newValue",
+            spyIsLocalBinding: true
+        )
+        // Bind the write spy to an explicitly typed local first.
+        //
+        // `super.<spy>` is a generic @dynamicMemberLookup subscript and
+        // `Interaction.init` is generic over Eff/Output, so with two or more
+        // indices neither side anchors those parameters and the closure's
+        // contextual result type is not enough to recover them:
+        //   error: generic parameter 'Eff' could not be inferred
+        // Swift 6.3 happens to solve it; 5.9 and 6.0 (both on CI) do not.
+        // Spelling the spy's type removes the ambiguity on every toolchain.
+        let spyBinding = VariableDeclSyntax(
+            bindingSpecifier: .keyword(.let),
+            bindings: PatternBindingListSyntax {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier(writeSpyBindingName)),
+                    typeAnnotation: TypeAnnotationSyntax(
+                        colon: .colonToken(trailingTrivia: .space),
+                        type: writeSpyType
+                    ),
+                    initializer: InitializerClauseSyntax(
+                        equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space),
+                        value: MemberAccessExprSyntax(
+                            base: SuperExprSyntax(),
+                            name: .identifier(setterSpyName)
+                        )
+                    )
+                )
+            }
+        )
+        // { newValue in\n<indent+2>let spy: …\n<indent+2>return Interaction(…)\n<indent+1>}
+        let setClosure = ClosureExprSyntax(
+            leftBrace: .leftBraceToken(),
+            signature: ClosureSignatureSyntax(
+                parameterClause: .simpleInput(ClosureShorthandParameterListSyntax {
+                    ClosureShorthandParameterSyntax(name: .identifier("newValue"))
+                }),
+                inKeyword: .keyword(.in)
+            ),
+            statements: CodeBlockItemListSyntax([
+                CodeBlockItemSyntax(
+                    leadingTrivia: .newline + indent(2),
+                    item: .decl(DeclSyntax(spyBinding))
+                ),
+                CodeBlockItemSyntax(
+                    leadingTrivia: .newline + indent(2),
+                    item: .stmt(StmtSyntax(ReturnStmtSyntax(
+                        returnKeyword: .keyword(.return, trailingTrivia: .space),
+                        expression: ExprSyntax(setterCall)
+                    )))
+                )
+            ]),
+            rightBrace: .rightBraceToken(leadingTrivia: .newline + indent(1))
+        )
+        // SettableInteraction(\n<indent+1>get: …,\n<indent+1>setInteraction: …\n<indent>)
+        let wrapperCall = FunctionCallExprSyntax(
+            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("SettableInteraction")),
+            leftParen: .leftParenToken(),
+            arguments: LabeledExprListSyntax {
+                LabeledExprSyntax(
+                    leadingTrivia: .newline + indent(1),
+                    label: .identifier("get"),
+                    colon: .colonToken(trailingTrivia: .space),
+                    expression: getterCall,
+                    trailingComma: .commaToken()
+                )
+                LabeledExprSyntax(
+                    leadingTrivia: .newline + indent(1),
+                    label: .identifier("setInteraction"),
+                    colon: .colonToken(trailingTrivia: .space),
+                    expression: setClosure
+                )
+            },
+            rightParen: .rightParenToken(leadingTrivia: .newline + indent(0))
+        )
+
+        return CodeBlockSyntax(statements: [CodeBlockItemSyntax(item: .expr(ExprSyntax(wrapperCall)))])
     }
 
     /// Creates a getter interaction function for a variable.
@@ -309,18 +462,53 @@ public extension MockableGenerator {
         )
     }
 
-    /// Wraps a type in `ArgMatcher<...>` for interaction parameter clauses.
-    private static func argMatcherType(_ type: TypeSyntax) -> TypeSyntax {
-        TypeSyntax(
-            IdentifierTypeSyntax(
-                name: .identifier("ArgMatcher"),
-                genericArgumentClause: GenericArgumentClauseSyntax {
-                    #if canImport(SwiftSyntax601)
-                    GenericArgumentSyntax(argument: .init(type))
-                    #else
-                    GenericArgumentSyntax(argument: (type))
-                    #endif
-                }
+    /// Creates a settable interaction function for a variable.
+    ///
+    /// For a settable variable `var value: Int { get set }`, this will generate:
+    /// ```swift
+    /// func value(_ void: Void) -> SettableInteraction<Void, Int> {
+    ///     SettableInteraction(
+    ///         get: Interaction(.any, spy: super.value),
+    ///         setInteraction: { newValue in
+    ///             Interaction(.any, newValue, spy: super.setValue)
+    ///         }
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// The read pack is `(Void)`, matching the conformance getter's
+    /// `adapt(super.value, ())`; the write pack is `(Void, newValue)`, matching
+    /// the conformance setter's `adapt(super.setValue, (), newValue)` — writes
+    /// record the read pack plus the written value.
+    private static func createSettableGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
+        let voidParameter = FunctionParameterSyntax(
+            firstName: .wildcardToken(),
+            secondName: .identifier("void"),
+            colon: .colonToken(trailingTrivia: .space),
+            type: IdentifierTypeSyntax(name: .identifier("Void"))
+        )
+        return FunctionDeclSyntax(
+            modifiers: modifiers.trimmed,
+            name: .identifier(varName),
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax(
+                    parameters: FunctionParameterListSyntax([voidParameter])
+                ),
+                returnClause: createSettableInteractionReturnType(
+                    inputTypes: [TypeSyntax(stringLiteral: "Void")],
+                    outputType: type,
+                    effectType: .none
+                )
+            ),
+            body: createSettableFunctionBody(
+                getterSpyName: varName,
+                setterSpyName: varName.setterSpyName,
+                parameterNames: FunctionParameterListSyntax([]),
+                // A variable's read pack is (Void), so the write pack is (Void, T).
+                writeSpyType: writeSpyType(
+                    inputTypes: [TypeSyntax(stringLiteral: "Void")],
+                    outputType: type
+                )
             )
         )
     }
@@ -448,6 +636,22 @@ public extension MockableGenerator {
 
     }
 
+    /// Wraps a type in `ArgMatcher<...>` for interaction parameter clauses.
+    private static func argMatcherType(_ type: TypeSyntax) -> TypeSyntax {
+        TypeSyntax(
+            IdentifierTypeSyntax(
+                name: .identifier("ArgMatcher"),
+                genericArgumentClause: GenericArgumentClauseSyntax {
+                    #if canImport(SwiftSyntax601)
+                    GenericArgumentSyntax(argument: .init(type))
+                    #else
+                    GenericArgumentSyntax(argument: (type))
+                    #endif
+                }
+            )
+        )
+    }
+
     private static func removeAttributes(_ type: TypeSyntaxProtocol) -> TypeSyntax {
         guard let attributedType = type.as(AttributedTypeSyntax.self) else {
             return TypeSyntax(fromProtocol: type)
@@ -530,7 +734,25 @@ public extension MockableGenerator {
     /// }
     /// ```
     private static func createFunctionBody(spyPropertyName: String, parameterNames: FunctionParameterListSyntax) -> CodeBlockSyntax {
-        let interactionCall = FunctionCallExprSyntax(
+        return CodeBlockSyntax(statements: [CodeBlockItemSyntax(item: .expr(ExprSyntax(interactionCall(spyPropertyName: spyPropertyName, parameterNames: parameterNames))))])
+    }
+
+    /// Creates an `Interaction(…, spy: super.<spy>)` call expression.
+    ///
+    /// Arguments are the read parameters (`.any` for an empty read pack, `.variadic(…)`
+    /// for variadic parameters), optionally followed by `newValueName` so the write
+    /// pack is the read pack plus the written value.
+    ///
+    /// - Parameter spyIsLocalBinding: When `true`, `spyPropertyName` names a local
+    ///   constant rather than a member, so the call passes it directly instead of
+    ///   through `super.`.
+    private static func interactionCall(
+        spyPropertyName: String,
+        parameterNames: FunctionParameterListSyntax,
+        newValueName: String? = nil,
+        spyIsLocalBinding: Bool = false
+    ) -> FunctionCallExprSyntax {
+        FunctionCallExprSyntax(
             callee: DeclReferenceExprSyntax(baseName: .identifier("Interaction"))
         ) {
             for parameter in parameterNames {
@@ -563,16 +785,35 @@ public extension MockableGenerator {
                 )
             }
 
+            if let newValueName {
+                LabeledExprSyntax(
+                    expression: DeclReferenceExprSyntax(baseName: .identifier(newValueName))
+                )
+            }
+
             LabeledExprSyntax(
                 label: "spy",
-                expression: MemberAccessExprSyntax(
-                    base: SuperExprSyntax(),
-                    name: .identifier(spyPropertyName)
-                )
+                expression: spyIsLocalBinding
+                    ? ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(spyPropertyName)))
+                    : ExprSyntax(MemberAccessExprSyntax(
+                        base: SuperExprSyntax(),
+                        name: .identifier(spyPropertyName)
+                    ))
             )
 
         }
+    }
 
-        return CodeBlockSyntax(statements: [CodeBlockItemSyntax(item: .expr(ExprSyntax(interactionCall)))])
+    /// The local constant generated set closures bind the write spy to.
+    static let writeSpyBindingName = "writeSpy"
+
+    /// Spells the write spy's type: `Spy<indices…, Output, None, Void>`.
+    ///
+    /// The write pack is the read pack plus the written value, and writes are
+    /// always non-effectful and return `Void`.
+    static func writeSpyType(inputTypes: [TypeSyntax], outputType: TypeSyntax) -> TypeSyntax {
+        let arguments = inputTypes.map(\.trimmedDescription)
+            + [outputType.trimmedDescription, "None", "Void"]
+        return TypeSyntax(stringLiteral: "Spy<\(arguments.joined(separator: ", "))>")
     }
 }

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -108,8 +108,8 @@ extension MockableGenerator {
                                                 ReturnStmtSyntax(
                                                     expression: adaptCall(
                                                         effectType: .none,
-                                                        requirementName: .identifier("set\(variableDecl.name.text.capitalized)"),
-                                                        parameters: [.identifier("newValue")]
+                                                        requirementName: .identifier(variableDecl.name.text.setterSpyName),
+                                                        parameters: [ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))]
                                                     )
                                                 )
                                             }
@@ -140,12 +140,13 @@ extension MockableGenerator {
     ///
     /// For a subscript `subscript(index: Int) -> String { get }`, this will generate a subscript with a getter that calls the mock's `adapt` function.
     /// For a settable requirement, it also generates a setter that records the write —
-    /// indices followed by `newValue` — on the `setSubscript` spy.
+    /// indices followed by `newValue` — on the `set` + capitalized-parameters spy.
     static func subscriptRequirement(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
-        let parameterNames = subscriptDecl.parameterClause.parameters.map({ $0.secondName ?? $0.firstName })
+        let parameterNames = subscriptDecl.parameterClause.parameters.map({ ExprSyntax(DeclReferenceExprSyntax(baseName: $0.secondName ?? $0.firstName)) })
         return SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
+            genericParameterClause: subscriptDecl.genericParameterClause,
             parameterClause: subscriptDecl.parameterClause,
             returnClause: subscriptDecl.returnClause,
             genericWhereClause: subscriptDecl.genericWhereClause,
@@ -160,8 +161,8 @@ extension MockableGenerator {
                                     ReturnStmtSyntax(
                                         expression: adaptCall(
                                             effectType: .none,
-                                            requirementName: .identifier("setSubscript"),
-                                            parameters: parameterNames + [.identifier("newValue")]
+                                            requirementName: .identifier(subscriptDecl.name.setterSpyName),
+                                            parameters: parameterNames + [ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))]
                                         )
                                     )
                                 }
@@ -174,7 +175,7 @@ extension MockableGenerator {
                                 ReturnStmtSyntax(
                                     expression: adaptCall(
                                         effectType: .none,
-                                        requirementName: .identifier("subscript"),
+                                        requirementName: .identifier(subscriptDecl.name),
                                         parameters: parameterNames
                                     )
                                 )
@@ -232,7 +233,7 @@ extension MockableGenerator {
             effectType: effectType,
             requirementName: functionDecl.name,
             parameters: functionDecl.signature.parameterClause.parameters
-                .map({ $0.secondName ?? $0.firstName})
+                .map({ ExprSyntax(DeclReferenceExprSyntax(baseName: $0.secondName ?? $0.firstName)) })
         )
     }
 
@@ -244,7 +245,7 @@ extension MockableGenerator {
     /// ```swift
     /// adapt(super.myMethod, param1)
     /// ```
-    private static func adaptCall(effectType: EffectType, requirementName: TokenSyntax, parameters: [TokenSyntax]) -> FunctionCallExprSyntax {
+    private static func adaptCall(effectType: EffectType, requirementName: TokenSyntax, parameters: [ExprSyntax]) -> FunctionCallExprSyntax {
         let adaptingName = "adapt" + (effectType.rawValue.contains("Throws") ? "Throwing" : "")
         return FunctionCallExprSyntax(
             calledExpression: DeclReferenceExprSyntax(
@@ -252,7 +253,7 @@ extension MockableGenerator {
             ),
             leftParen: .leftParenToken(),
             arguments: LabeledExprListSyntax {
-                // super.myMethoName
+                // super.myMethodName
                 LabeledExprSyntax(
                     expression: MemberAccessExprSyntax(
                         base: SuperExprSyntax(),
@@ -269,17 +270,12 @@ extension MockableGenerator {
                     )
                 } else {
                     for parameter in parameters {
-                        LabeledExprSyntax(
-                            expression: DeclReferenceExprSyntax.init(
-                                baseName: parameter
-                            )
-                        )
+                        LabeledExprSyntax(expression: parameter)
                     }
                 }
             },
             rightParen: .rightParenToken()
         )
-
     }
 }
 

--- a/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
+++ b/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
@@ -36,6 +36,53 @@ extension SubscriptDeclSyntax {
     }
 }
 
+extension String {
+    /// The string with its first character uppercased and the rest left intact.
+    ///
+    /// Distinct from `capitalized`, which lowercases everything after the first
+    /// character and so mangles camelCase spy names — `cachePolicy` would yield
+    /// `setCachepolicy` rather than `setCachePolicy`.
+    var upperCamelCased: String {
+        prefix(1).uppercased() + dropFirst()
+    }
+
+    /// The name of the write spy paired with this read-spy name.
+    var setterSpyName: String {
+        "set" + upperCamelCased
+    }
+}
+
+extension SubscriptDeclSyntax {
+    /// The spy name for the subscript: `subscript` followed by its parameter
+    /// names in camelCase — `subscript(row: Int, column: Int)` names
+    /// `subscriptRowColumn`, and a subscript with no named parameter is just
+    /// `subscript`.
+    ///
+    /// The prefix keeps subscripts in their own namespace. Without it a
+    /// subscript's spy name is indistinguishable from a method's or a
+    /// variable's — `func index(_:)` and `subscript(index:)` both derived
+    /// `index` — and requirements whose spy *signatures* also matched would
+    /// silently share one spy, so stubbing one answered calls to the other.
+    /// Since the name is ours to choose, namespacing removes the collision at
+    /// its source rather than asking users to rename their protocol members.
+    ///
+    /// Unlabeled parameters contribute their internal name. The write spy is
+    /// ``Swift/String/setterSpyName``, matching variables (`setValue`).
+    var name: String {
+        let names = parameterClause.parameters
+            .compactMap { parameter -> String? in
+                if let secondName = parameter.secondName {
+                    return secondName.text
+                }
+                return parameter.firstName.text == "_" ? nil : parameter.firstName.text
+            }
+        guard let first = names.first else {
+            return "subscript"
+        }
+        return "subscript" + ([first] + names.dropFirst()).map(\.upperCamelCased).joined()
+    }
+}
+
 extension AccessorBlockSyntax.Accessors {
   /// The list of accessors, if the accessor block is of the `.accessors` case.
   var settersAndGetters: AccessorDeclListSyntax? {

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -107,12 +107,12 @@ final class ProtocolFeaturesTests: MacroTestCase {
             class MockMyService: Mock, @unchecked Sendable, MyService {
                 subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String > {
                     get {
-                        Interaction(index, spy: super.subscript)
+                        Interaction(index, spy: super.subscriptIndex)
                     }
                 }
                 subscript(index: Int) -> String {
                     get {
-                        return adapt(super.subscript, index)
+                        return adapt(super.subscriptIndex, index)
                     }
                 }
             }
@@ -137,20 +137,122 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
             #if DEBUG
             class MockMyService: Mock, @unchecked Sendable, MyService {
-                subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String > {
+                subscript(index: ArgMatcher<Int>) -> SettableInteraction<Int, None, String > {
                     get {
-                        Interaction(index, spy: super.subscript)
+                        SettableInteraction(
+                            get: Interaction(index, spy: super.subscriptIndex),
+                            setInteraction: { newValue in
+                                let writeSpy: Spy<Int, String, None, Void> = super.setSubscriptIndex
+                                return Interaction(index, newValue, spy: writeSpy)
+                            }
+                        )
                     }
-                }
-                func setSubscript(index: ArgMatcher<Int>, newValue: ArgMatcher<String >) -> Interaction<Int, String , None, Void> {
-                    Interaction(index, newValue, spy: super.setSubscript)
                 }
                 subscript(index: Int) -> String {
                     set {
-                        return adapt(super.setSubscript, index, newValue)
+                        return adapt(super.setSubscriptIndex, index, newValue)
                     }
                     get {
-                        return adapt(super.subscript, index)
+                        return adapt(super.subscriptIndex, index)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    /// The generic clause must land on every generated declaration — both the
+    /// interaction subscript and the conformance subscript — or the expansion
+    /// references an undeclared type parameter.
+    func testProtocolWithGenericSubscript() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol MyService {
+                subscript<T: Hashable>(item: T) -> String { get }
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                subscript<T: Hashable>(item: T) -> String { get }
+            }
+
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                subscript <T: Hashable>(item: ArgMatcher<T>) -> Interaction<T, None, String > {
+                    get {
+                        Interaction(item, spy: super.subscriptItem)
+                    }
+                }
+                subscript <T: Hashable>(item: T) -> String {
+                    get {
+                        return adapt(super.subscriptItem, item)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    func testProtocolWithMultiParameterSubscript() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol MyService {
+                subscript(row: Int, column: Int) -> String { get }
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                subscript(row: Int, column: Int) -> String { get }
+            }
+
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                subscript(row: ArgMatcher<Int>, column: ArgMatcher<Int>) -> Interaction<Int, Int, None, String > {
+                    get {
+                        Interaction(row, column, spy: super.subscriptRowColumn)
+                    }
+                }
+                subscript(row: Int, column: Int) -> String {
+                    get {
+                        return adapt(super.subscriptRowColumn, row, column)
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    func testProtocolWithUnlabeledSubscript() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol MyService {
+                subscript(_ position: Int) -> String { get }
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                subscript(_ position: Int) -> String { get }
+            }
+
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                subscript(_ position: ArgMatcher<Int>) -> Interaction<Int, None, String > {
+                    get {
+                        Interaction(position, spy: super.subscriptPosition)
+                    }
+                }
+                subscript(_ position: Int) -> String {
+                    get {
+                        return adapt(super.subscriptPosition, position)
                     }
                 }
             }

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -143,7 +143,8 @@ final class ProtocolFeaturesTests: MacroTestCase {
                             get: Interaction(index, spy: super.subscriptIndex),
                             setInteraction: { newValue in
                                 let writeSpy: Spy<Int, String, None, Void> = super.setSubscriptIndex
-                                return Interaction(index, newValue, spy: writeSpy)
+                                let writeInteraction: Interaction<Int, String, None, Void> = Interaction(index, newValue, spy: writeSpy)
+                                return writeInteraction
                             }
                         )
                     }

--- a/Tests/SwiftMockingTests/GenericSubscriptTests.swift
+++ b/Tests/SwiftMockingTests/GenericSubscriptTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import SwiftMocking
+import SwiftMockingTestSupport
+
+/// Generic subscripts must carry their generic clause onto every generated
+/// declaration; without it the expansion references an undeclared parameter.
+///
+/// Note the stubbing site needs `.any(String.self)` rather than a bare `.any`:
+/// nothing else in `when(mock[...])` pins the subscript's generic parameter, so
+/// the type must come from the matcher.
+@Mockable
+protocol GenericSubscriptService {
+    subscript<T: Hashable>(item: T) -> String { get }
+}
+
+@Mockable
+protocol GenericSettableSubscriptService {
+    subscript<T: Hashable>(item: T) -> String { get set }
+}
+
+final class GenericSubscriptTests: MockingTestCase {
+    func testGenericSubscriptReadStubsAndVerifies() {
+        let mock = MockGenericSubscriptService()
+        let svc: GenericSubscriptService = mock
+        when(mock[.any(String.self)]).thenReturn("stubbed")
+
+        XCTAssertEqual(svc["key"], "stubbed")
+        verify(mock[.equal("key")]).called(1)
+    }
+
+    func testGenericSettableSubscriptRoundTrips() {
+        let mock = MockGenericSettableSubscriptService()
+        var svc: GenericSettableSubscriptService = mock
+        when(mock[.any(String.self)]).thenReturn("read")
+
+        XCTAssertEqual(svc["k"], "read")
+        svc["k"] = "written"
+
+        verify(mock[.equal("k")]).called(1)
+        verify(mock[.equal("k")] <- "written").called(1)
+    }
+}

--- a/Tests/SwiftMockingTests/SubscriptInteractionTests.swift
+++ b/Tests/SwiftMockingTests/SubscriptInteractionTests.swift
@@ -12,23 +12,39 @@ protocol SettableSubscriptService {
     subscript(index: Int) -> String { get set }
 }
 
+/// A method and a subscript whose derived spy names would otherwise both be
+/// `index`. Subscript spies are namespaced (`subscriptIndex`), so the two stay
+/// independent.
+@Mockable
+protocol NamespacedSpyService {
+    func index(_ value: Int) -> String
+    subscript(index: Int) -> String { get set }
+}
+
+@Mockable
+protocol MatrixService {
+    subscript(row: Int, column: Int) -> String { get set }
+}
+
 /// End-to-end coverage for protocol subscript requirements.
 ///
 /// The macro expansions are covered in `ProtocolFeaturesTests` (get-only and
 /// get-set); these tests exercise the generated mocks at runtime.
 ///
 /// Reads stub and verify through the `ArgMatcher` interaction subscript
-/// (`mock[.any]`). Writes record on a separate `setSubscript` spy with the
-/// written value as a trailing argument, mirroring `setValue(newValue:)` for
-/// properties — reached via `mock.setSubscript(index:newValue:)`.
+/// (`mock[.any]`). Settable requirements surface a `SettableInteraction`:
+/// reads use it directly (`when(mock[.any])`), writes build a plain write
+/// interaction with the `<-` operator — `verify(mock[.any] <- "one")` —
+/// recording the written value after the index on a dedicated spy.
 final class SubscriptInteractionTests: MockingTestCase {
     // MARK: Get
 
     func testSubscriptGetter_StubbedValueIsReturned() {
         let mock = MockSubscriptService()
+        let service: SubscriptService = mock
         when(mock[.any]).thenReturn("stubbed")
 
-        let result = mock[42]
+        let result = service[42]
 
         XCTAssertEqual(result, "stubbed")
     }
@@ -70,7 +86,7 @@ final class SubscriptInteractionTests: MockingTestCase {
 
         service[0] = "written"
 
-        verify(mock.setSubscript(index: .any, newValue: .any)).called(1)
+        verify(mock[.any] <- .any).called(1)
     }
 
     func testSubscriptSetter_VerificationRespectsArgumentMatchers() {
@@ -81,15 +97,15 @@ final class SubscriptInteractionTests: MockingTestCase {
         service[2] = "two"
         service[2] = "two"
 
-        verify(mock.setSubscript(index: .equal(1), newValue: .equal("one"))).called(1)
-        verify(mock.setSubscript(index: .equal(2), newValue: .equal("two"))).called(2)
-        verify(mock.setSubscript(index: .any, newValue: .any)).called(3)
+        verify(mock[.equal(1)].set(.equal("one"))).called(1)
+        verify(mock[.equal(2)] <- .equal("two")).called(2)
+        verify(mock[.any] <- .any).called(3)
     }
 
     func testSubscriptSetter_NeverCalledVerification() {
         let mock = MockSettableSubscriptService()
 
-        verifyNever(mock.setSubscript(index: .any, newValue: .any))
+        verifyNever(mock[.any] <- .any)
     }
 
     // MARK: Get and set are independent interactions
@@ -100,11 +116,13 @@ final class SubscriptInteractionTests: MockingTestCase {
 
         _ = service[1]
         service[1] = "one"
+        service[1] = "one"
         service[2] = "two"
 
         verify(mock[.any]).called(1)
-        verify(mock.setSubscript(index: .any, newValue: .any)).called(2)
-        verify(mock.setSubscript(index: .equal(1), newValue: .any)).called(1)
+        verify(mock[.equal(1)] <- "one").called(2)
+        verify(mock[.equal(2)] <- "two").called()
+        verify(mock[.any] <- .any).called(3)
     }
 
     func testSettableSubscript_GetterStillStubbable() {
@@ -114,5 +132,42 @@ final class SubscriptInteractionTests: MockingTestCase {
 
         XCTAssertEqual(service[7], "stubbed")
         verify(mock[.any]).called(1)
+    }
+
+    func testMultiParameterSubscript_SpyNamedFromConcatenatedParameters() {
+        let mock = MockMatrixService()
+        var service: MatrixService = mock
+        when(mock[.any, .any]).thenReturn("cell")
+
+        XCTAssertEqual(service[1, 2], "cell")
+        service[1, 2] = "written"
+
+        verify(mock[.equal(1), .equal(2)]).called(1)
+        // Bind first: forwarding a pack-rearranged result (`Interaction<I…, O,
+        // None, Void>`) straight into another generic call does not infer for
+        // multi-index packs on this toolchain. Single-index subscripts and
+        // variables ((Void) packs) chain fine: `verify(mock.value <- 7)`.
+        let write = mock[.equal(1), .equal(2)] <- "written"
+        verify(write).called(1)
+        verifyNever(mock[.equal(2), .equal(1)])
+    }
+
+    // MARK: Spy namespacing
+
+    func testSubscriptAndMethodOfSameNameUseIndependentSpies() {
+        let mock = MockNamespacedSpyService()
+        var service: NamespacedSpyService = mock
+        when(mock.index(.any)).thenReturn("from-method")
+        when(mock[.any]).thenReturn("from-subscript")
+
+        XCTAssertEqual(service.index(1), "from-method")
+        XCTAssertEqual(service[1], "from-subscript")
+        service[1] = "written"
+
+        verify(mock.index(.equal(1))).called(1)
+        verify(mock[.equal(1)]).called(1)
+        verify(mock[.equal(1)] <- "written").called(1)
+        // The write landed on the subscript's spy, not the method's.
+        verify(mock.index(.any)).called(1)
     }
 }

--- a/Tests/SwiftMockingTests/SubscriptInteractionTests.swift
+++ b/Tests/SwiftMockingTests/SubscriptInteractionTests.swift
@@ -143,11 +143,17 @@ final class SubscriptInteractionTests: MockingTestCase {
         service[1, 2] = "written"
 
         verify(mock[.equal(1), .equal(2)]).called(1)
-        // Bind first: forwarding a pack-rearranged result (`Interaction<I…, O,
-        // None, Void>`) straight into another generic call does not infer for
-        // multi-index packs on this toolchain. Single-index subscripts and
-        // variables ((Void) packs) chain fine: `verify(mock.value <- 7)`.
-        let write = mock[.equal(1), .equal(2)] <- "written"
+        // `<-` returns `Interaction<repeat each Input, Output, None, Void>`, so
+        // feeding it straight to `verify` asks the solver to split a concrete
+        // `Int, Int, String` back into `each Input` plus `Output`. Pack suffix
+        // splitting is not inferable, on any toolchain through at least 6.3:
+        //   error: pack expansion requires that 'Int, Int' and '_' have the
+        //          same shape
+        // Annotating the local states the pack. Single-index subscripts and
+        // variables are unaffected — a one-element pack has one possible split
+        // — so `verify(mock[.equal(1)] <- "one")` above needs no annotation.
+        let write: Interaction<Int, Int, String, None, Void> =
+            mock[.equal(1), .equal(2)] <- "written"
         verify(write).called(1)
         verifyNever(mock[.equal(2), .equal(1)])
     }


### PR DESCRIPTION
Third of a six-PR stack (#105). Based on #100.

Wires **settable subscripts** to `SettableInteraction`. Reads stub and verify as before; writes go through `<-`:

```swift
when(mock[.any]).thenReturn("v")
mock[1] = "written"
verify(mock[.equal(1)] <- "written").called(1)
```

Two generator fixes that only matter once subscripts use this shape:

- **Spy names gain a `subscript` prefix** — `subscript(index:)` → `subscriptIndex`, paired with `setSubscriptIndex`. Without it a subscript's spy name is indistinguishable from a method's, so `func index(_:)` and `subscript(index:)` shared one spy whenever their signatures also matched.
- **Generic subscripts** now carry `genericParameterClause`/`genericWhereClause` onto every generated declaration; previously they referenced an undeclared type parameter and failed to compile. Note stubbing needs `when(mock[.any(String.self)])` — nothing else pins the generic parameter.

Variables keep their existing getter/`setX` shape here; that migration is #102.

**Tests:** 202 pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mocking support for get/set subscripts through combined interactions.
  * Added support for generic, multi-parameter, unlabeled, and unnamed subscripts.
  * Added parameter-specific spy names for clearer subscript stubbing and verification.
  * Enabled independent verification of subscript reads and writes, including written-value matching.
  * Added support for testing generic subscript reads, writes, and round trips.

* **Bug Fixes**
  * Improved handling of subscript and method naming conflicts.
  * Preserved generic subscript information during generated mock interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->