### PR TITLE
Emit SettableInteraction for settable variables

### DIFF
--- a/Examples/Tests/ExamplesTests/ExampleXCTests.swift
+++ b/Examples/Tests/ExamplesTests/ExampleXCTests.swift
@@ -254,9 +254,9 @@ final class MockitoTests: XCTestCase {
         XCTAssertEqual(mock.value, 42)
         verify(mock.value).called(1)
 
-        // Setter verification goes through setValue(newValue:)
+        // Setter verification reads like the assignment itself
         mock.value = 7
-        verify(mock.setValue(newValue: .equal(7))).called(1)
+        verify(mock.value <- 7).called(1)
     }
 
     func testVariadic() {

--- a/Examples/Tests/ExamplesTests/ExamplesTests.swift
+++ b/Examples/Tests/ExamplesTests/ExamplesTests.swift
@@ -206,9 +206,9 @@ struct ExampleTests {
         #expect(mock.value == 42)
         verify(mock.value).called(1)
 
-        // Setter verification goes through setValue(newValue:)
+        // Setter verification reads like the assignment itself
         mock.value = 7
-        verify(mock.setValue(newValue: .equal(7))).called(1)
+        verify(mock.value <- 7).called(1)
     }
 
     @Test func testNetworkService() async throws {

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -91,23 +91,20 @@ public extension MockableGenerator {
                 continue
             }
 
-            let hasSetter = varDecl.hasSetter
-
-            // Getter
-            let getter = createGetterInteraction(
-                varName: varName,
-                type: type,
-                modifiers: varDecl.modifiers
-            )
-            decls.append(DeclSyntax(getter))
-
-            if hasSetter {
-                let setter = createSetterInteraction(
+            if varDecl.hasSetter {
+                decls.append(DeclSyntax(createSettableGetterInteraction(
+                    varName: varName,
+                    type: type,
+                    modifiers: varDecl.modifiers
+                )))
+            } else {
+                // Getter
+                let getter = createGetterInteraction(
                     varName: varName,
                     type: type,
                     modifiers: varDecl.modifiers
                 )
-                decls.append(DeclSyntax(setter))
+                decls.append(DeclSyntax(getter))
             }
         }
         return decls
@@ -472,42 +469,6 @@ public extension MockableGenerator {
         )
     }
 
-    /// Creates a setter interaction function for a variable.
-    ///
-    /// For a variable `var name: String`, this will generate:
-    /// ```swift
-    /// func setName(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> { ... }
-    /// ```
-    private static func createSetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
-        let setterName = "set" + varName.capitalized
-        let parameter = FunctionParameterSyntax(
-            firstName: .identifier("newValue"),
-            colon: .colonToken(trailingTrivia: .space),
-            type: argMatcherType(type)
-        )
-        let parameterList = FunctionParameterListSyntax([parameter])
-        let interactionReturnType = createInteractionReturnType(inputTypes: [type], outputType: TypeSyntax(stringLiteral: "Void"), effectType: .none, genericParameterClause: nil)
-        let body = createFunctionBody(
-            spyPropertyName: setterName,
-            parameterNames: FunctionParameterListSyntax {
-                FunctionParameterSyntax.init(
-                    firstName: .identifier("newValue"),
-                    type: type
-                )
-            }
-        )
-
-        return FunctionDeclSyntax(
-            modifiers: modifiers.trimmed,
-            name: .identifier(setterName),
-            signature: FunctionSignatureSyntax(
-                parameterClause: FunctionParameterClauseSyntax(parameters: parameterList),
-                returnClause: interactionReturnType
-            ),
-            body: body
-        )
-    }
-
     /// Creates a settable interaction function for a variable.
     ///
     /// For a settable variable `var value: Int { get set }`, this will generate:
@@ -684,22 +645,6 @@ public extension MockableGenerator {
 
         return FunctionParameterClauseSyntax(parameters: paramList)
 
-    }
-
-    /// Wraps a type in `ArgMatcher<...>` for interaction parameter clauses.
-    private static func argMatcherType(_ type: TypeSyntax) -> TypeSyntax {
-        TypeSyntax(
-            IdentifierTypeSyntax(
-                name: .identifier("ArgMatcher"),
-                genericArgumentClause: GenericArgumentClauseSyntax {
-                    #if canImport(SwiftSyntax601)
-                    GenericArgumentSyntax(argument: .init(type))
-                    #else
-                    GenericArgumentSyntax(argument: (type))
-                    #endif
-                }
-            )
-        )
     }
 
     private static func removeAttributes(_ type: TypeSyntaxProtocol) -> TypeSyntax {

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -77,7 +77,7 @@ public extension MockableGenerator {
     ///
     /// For a variable `var name: String { get set }`, this will generate:
     /// ```swift
-    /// func name(_ void: Void) -> Interaction<Void, None, String> { ... }
+    /// func name(_ void: Void = ()) -> Interaction<Void, None, String> { ... }
     /// func setName(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> { ... }
     /// ```
     private static func processVar(_ varDecl: VariableDeclSyntax) -> [DeclSyntax] {
@@ -434,7 +434,7 @@ public extension MockableGenerator {
     ///
     /// For a variable `var name: String`, this will generate:
     /// ```swift
-    /// func name(_ void: Void) -> Interaction<Void, None, String> { ... }
+    /// func name(_ void: Void = ()) -> Interaction<Void, None, String> { ... }
     /// ```
     ///
     /// The `Void` parameter is load-bearing, not cosmetic:
@@ -450,12 +450,6 @@ public extension MockableGenerator {
     private static func createGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
         let interactionReturnType = createInteractionReturnType(inputTypes: [], outputType: type, effectType: .none, genericParameterClause: nil)
         let body = createFunctionBody(spyPropertyName: varName, parameterNames: [])
-        let voidParameter = FunctionParameterSyntax(
-            firstName: .wildcardToken(),
-            secondName: .identifier("void"),
-            colon: .colonToken(trailingTrivia: .space),
-            type: IdentifierTypeSyntax(name: .identifier("Void"))
-        )
         return FunctionDeclSyntax(
             modifiers: modifiers.trimmed,
             name: .identifier(varName),
@@ -473,7 +467,7 @@ public extension MockableGenerator {
     ///
     /// For a settable variable `var value: Int { get set }`, this will generate:
     /// ```swift
-    /// func value(_ void: Void) -> SettableInteraction<Void, Int> {
+    /// func value(_ void: Void = ()) -> SettableInteraction<Void, Int> {
     ///     SettableInteraction(
     ///         get: Interaction(.any, spy: super.value),
     ///         setInteraction: { newValue in
@@ -488,13 +482,7 @@ public extension MockableGenerator {
     /// the conformance setter's `adapt(super.setValue, (), newValue)` — writes
     /// record the read pack plus the written value.
     private static func createSettableGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
-        let voidParameter = FunctionParameterSyntax(
-            firstName: .wildcardToken(),
-            secondName: .identifier("void"),
-            colon: .colonToken(trailingTrivia: .space),
-            type: IdentifierTypeSyntax(name: .identifier("Void"))
-        )
-        return FunctionDeclSyntax(
+        FunctionDeclSyntax(
             modifiers: modifiers.trimmed,
             name: .identifier(varName),
             signature: FunctionSignatureSyntax(
@@ -520,6 +508,25 @@ public extension MockableGenerator {
                     inputTypes: [TypeSyntax(stringLiteral: "Void")],
                     outputType: type
                 )
+            )
+        )
+    }
+
+    /// The placeholder parameter variable interactions take in place of arguments: `_ void: Void = ()`.
+    ///
+    /// The parameter itself is load-bearing (see `createGetterInteraction`); the
+    /// default value keeps direct calls reading like the property they stand for —
+    /// `mock.name()` rather than `mock.name(())` — without disturbing the unapplied
+    /// reference `mock.name`, which `when`/`verify` still see as `(Void) -> …`.
+    private static var voidParameter: FunctionParameterSyntax {
+        FunctionParameterSyntax(
+            firstName: .wildcardToken(),
+            secondName: .identifier("void"),
+            colon: .colonToken(trailingTrivia: .space),
+            type: IdentifierTypeSyntax(name: .identifier("Void")),
+            defaultValue: InitializerClauseSyntax(
+                equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space),
+                value: TupleExprSyntax(elements: LabeledExprListSyntax([]))
             )
         )
     }

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -109,7 +109,7 @@ extension MockableGenerator {
                                                     expression: adaptCall(
                                                         effectType: .none,
                                                         requirementName: .identifier(variableDecl.name.text.setterSpyName),
-                                                        parameters: [ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))]
+                                                        parameters: [ExprSyntax(TupleExprSyntax(elements: LabeledExprListSyntax())), ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))]
                                                     )
                                                 )
                                             }

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -47,7 +47,7 @@ final class GeneratorPipelineTests: XCTestCase {
             """
             #if DEBUG
             class MockMyService: Mock, @unchecked Sendable, MyService {
-                func value(_ void: Void) -> Interaction<Void, None, Int > {
+                func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
 

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -65,6 +65,89 @@ final class ProtocolFeaturesTests: MacroTestCase {
         }
     }
 
+    func testProtocolWithSettableProperty() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol MyService {
+                var value: Int { get set }
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                var value: Int { get set }
+            }
+
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                func value(_ void: Void) -> SettableInteraction<Void, None, Int > {
+                    SettableInteraction(
+                        get: Interaction(.any, spy: super.value),
+                        setInteraction: { newValue in
+                            let writeSpy: Spy<Void, Int, None, Void> = super.setValue
+                            return Interaction(.any, newValue, spy: writeSpy)
+                        }
+                    )
+                }
+
+                    var value: Int {
+                    set {
+                        return adapt(super.setValue, (), newValue)
+                    }
+                    get {
+                        adapt(super.value, ())
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    /// Setter spy names uppercase only the first character. `String.capitalized`
+    /// would lowercase the tail — `setCachepolicy` — which still round-trips at
+    /// runtime (both sides agree) but reads as a typo in generated source.
+    func testProtocolWithSettableMultiWordProperty() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol MyService {
+                var cachePolicy: String { get set }
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                var cachePolicy: String { get set }
+            }
+
+            #if DEBUG
+            class MockMyService: Mock, @unchecked Sendable, MyService {
+                func cachePolicy(_ void: Void) -> SettableInteraction<Void, None, String > {
+                    SettableInteraction(
+                        get: Interaction(.any, spy: super.cachePolicy),
+                        setInteraction: { newValue in
+                            let writeSpy: Spy<Void, String, None, Void> = super.setCachePolicy
+                            return Interaction(.any, newValue, spy: writeSpy)
+                        }
+                    )
+                }
+
+                    var cachePolicy: String {
+                    set {
+                        return adapt(super.setCachePolicy, (), newValue)
+                    }
+                    get {
+                        adapt(super.cachePolicy, ())
+                    }
+                }
+            }
+            #endif
+            """
+        }
+    }
+
     func testProtocolWithInitializer() {
         assertMacro {
             """

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -50,7 +50,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
             #if DEBUG
             class MockMyService: Mock, @unchecked Sendable, MyService {
-                func value(_ void: Void) -> Interaction<Void, None, Int > {
+                func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
 
@@ -81,12 +81,13 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
             #if DEBUG
             class MockMyService: Mock, @unchecked Sendable, MyService {
-                func value(_ void: Void) -> SettableInteraction<Void, None, Int > {
+                func value(_ void: Void = ()) -> SettableInteraction<Void, None, Int > {
                     SettableInteraction(
                         get: Interaction(.any, spy: super.value),
                         setInteraction: { newValue in
                             let writeSpy: Spy<Void, Int, None, Void> = super.setValue
-                            return Interaction(.any, newValue, spy: writeSpy)
+                            let writeInteraction: Interaction<Void, Int, None, Void> = Interaction(.any, newValue, spy: writeSpy)
+                            return writeInteraction
                         }
                     )
                 }
@@ -124,12 +125,13 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
             #if DEBUG
             class MockMyService: Mock, @unchecked Sendable, MyService {
-                func cachePolicy(_ void: Void) -> SettableInteraction<Void, None, String > {
+                func cachePolicy(_ void: Void = ()) -> SettableInteraction<Void, None, String > {
                     SettableInteraction(
                         get: Interaction(.any, spy: super.cachePolicy),
                         setInteraction: { newValue in
                             let writeSpy: Spy<Void, String, None, Void> = super.setCachePolicy
-                            return Interaction(.any, newValue, spy: writeSpy)
+                            let writeInteraction: Interaction<Void, String, None, Void> = Interaction(.any, newValue, spy: writeSpy)
+                            return writeInteraction
                         }
                     )
                 }

--- a/Tests/SwiftMockingTests/SettablePropertyInteractionTests.swift
+++ b/Tests/SwiftMockingTests/SettablePropertyInteractionTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import SwiftMocking
+import SwiftMockingTestSupport
+
+@Mockable
+protocol MutableService {
+    var value: Int { get set }
+    var cachePolicy: String { get set }
+    func refresh()
+}
+
+/// End-to-end coverage for settable variable requirements.
+///
+/// Settable variables surface a `SettableInteraction` through their getter
+/// interaction member (`mock.value`): reads stub and verify unchanged
+/// (`when(mock.value)` / `verify(mock.value)`), writes build a plain write
+/// interaction with the `<-` operator, and the result composes with
+/// `verifyInOrder` and `captured`. Writes record `(Void, newValue)` — the
+/// read pack plus the written value.
+///
+/// These drive the mock directly (`mock.value = 7`) rather than through a
+/// protocol-typed reference: for a *property*, the runtime member is a `var`
+/// and the interaction member is a `func`, so neither reads nor writes are
+/// ambiguous. Zero-arg *methods* like `refresh()` do need the protocol type.
+final class SettablePropertyInteractionTests: MockingTestCase {
+    func testPropertyGetter_StillStubbedThroughWrapper() {
+        let mock = MockMutableService()
+        when(mock.value).thenReturn(7)
+
+        XCTAssertEqual(mock.value, 7)
+        verify(mock.value).called(1)
+    }
+
+    func testPropertyWrite_VerifiedWithAssigned() {
+        let mock = MockMutableService()
+        mock.value = 7
+
+        verify(mock.value <- 7).called(1)
+    }
+
+    func testPropertyWrite_AssignedAcceptsLiteralMatcher() {
+        let mock = MockMutableService()
+        mock.value = 7
+        mock.value = 9
+        verify(mock.value <- 7).called(1)
+        verify(mock.value <- .greaterThan(8)).called(1)
+    }
+
+    func testPropertyWrite_VerificationRespectsExplicitSetForm() {
+        let mock = MockMutableService()
+
+        mock.value = 7
+        mock.value = 9
+        mock.value = 9
+
+        verify(mock.value(()).set(.equal(7))).called(1)
+        verify(mock.value(()).set(.equal(9))).called(2)
+    }
+
+    func testPropertyWrite_NeverAssigned() {
+        let mock = MockMutableService()
+
+        verifyNever(mock.value <- .any)
+    }
+
+    func testPropertyWrite_StubbedSideEffectRunsOnAssignment() {
+        let mock = MockMutableService()
+        let written = CaptureBox<Int>()
+        when(mock.value <- 7).thenReturn { _, newValue in
+            written.append(newValue)
+        }
+
+        mock.value = 7
+        mock.value = 8
+
+        // Only the matched write runs the handler.
+        XCTAssertEqual(written.values, [7])
+    }
+
+    func testProperty_GetAndSetAreRecordedOnSeparateSpies() {
+        let mock = MockMutableService()
+
+        _ = mock.value
+        mock.value = 1
+        mock.value = 2
+
+        verify(mock.value).called(1)
+        verify(mock.value <- .any).called(2)
+    }
+
+    func testPropertyWrite_ComposesWithVerifyInOrder() {
+        let mock = MockMutableService()
+        let service: MutableService = mock
+
+        mock.value = 7
+        // Zero-arg methods are ambiguous on the mock type (runtime vs.
+        // interaction member) — unlike properties, they need the protocol type.
+        service.refresh()
+
+        verifyInOrder([
+            mock.value <- 7,
+            mock.refresh()
+        ])
+    }
+
+    func testPropertyWrite_CapturedArgumentsIncludeNewValue() {
+        let mock = MockMutableService()
+
+        mock.value = 7
+
+        // Writes record the read pack first, then the written value.
+        verify(mock.value <- .any).captured { _, newValue in
+            XCTAssertEqual(newValue, 7)
+        }
+    }
+
+    /// The read and write spies must agree on a camelCase name. `String.capitalized`
+    /// lowercases the tail (`cachePolicy` → `setCachepolicy`), which is self-consistent
+    /// and so invisible to a round-trip test — but wrong in generated source people read.
+    func testMultiWordProperty_ReadAndWriteSpiesRoundTrip() {
+        let mock = MockMutableService()
+        when(mock.cachePolicy).thenReturn("none")
+
+        XCTAssertEqual(mock.cachePolicy, "none")
+        mock.cachePolicy = "aggressive"
+
+        verify(mock.cachePolicy).called(1)
+        verify(mock.cachePolicy <- "aggressive").called(1)
+    }
+
+    func testPropertyRead_VerifiedThroughWrapper() {
+        let mock = MockMutableService()
+        let service: MutableService = mock
+
+        // Reads also route correctly through a protocol-typed reference —
+        // the shape a SUT under test actually holds.
+        _ = service.value
+
+        verify(mock.value).called(1)
+    }
+}

--- a/Tests/SwiftMockingTests/SpyTests.swift
+++ b/Tests/SwiftMockingTests/SpyTests.swift
@@ -1,6 +1,7 @@
 
 import XCTest
 @testable import SwiftMocking
+import SwiftMockingTestSupport
 
 final class SpyTests: XCTestCase {
 
@@ -195,22 +196,8 @@ final class SpyTests: XCTestCase {
     }
 
     func test_whenHelperFiltersSpecificInteraction() {
-        final class CaptureBox: @unchecked Sendable {
-            private let lock = NSLock()
-            private var items: [String] = []
-            func append(_ item: String) {
-                lock.lock()
-                items.append(item)
-                lock.unlock()
-            }
-            var values: [String] {
-                lock.lock()
-                defer { lock.unlock() }
-                return items
-            }
-        }
         let spy = Spy<String, None, Void>()
-        let captured = CaptureBox()
+        let captured = CaptureBox<String>()
 
         when(spy(.equal("track"))).do({ value in
             captured.append(value)


### PR DESCRIPTION
Fourth of a six-PR stack (#105). Based on #101.

Moves **settable variables** onto `SettableInteraction`, matching subscripts. Reads keep working through `when(mock.value)` / `verify(mock.value)`; writes go through `verify(mock.value <- 7)`. The separate `setValue(newValue:)` interaction member is gone.

The conformance setter now passes the read pack explicitly — `adapt(super.setValue, (), newValue)` — so a write records `(Void, newValue)`: the read pack plus the written value, the same shape subscripts use.

**Bug fix:** setter spy names used `String.capitalized`, which lowercases the tail — `cachePolicy` produced `setCachepolicy`. Both sides agreed, so it round-tripped at runtime and every test passed; it was only wrong in generated source people read. Now only the first character is uppercased. Covered by a macro snapshot, since a runtime test can't catch a self-consistent mangling.

Also migrates the Examples project to `<-`.

**Tests:** 215 pass (main), 19 (Examples).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settable mock properties now support streamlined assignment-style verification, including literals and matchers.
  * Added comprehensive support for stubbing, verifying, capturing, ordering, and checking writes to mutable properties.
  * Property interactions now support convenient zero-argument access.

* **Bug Fixes**
  * Improved handling of getter and setter interactions, including multi-word property names and separate read/write spies.

* **Tests**
  * Expanded coverage for mutable property behavior and protocol property generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->