### PR TITLE
Reject requirements that would share a spy

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+Source.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Source.swift
@@ -37,12 +37,23 @@ public enum MockableGeneratorError: Error, Equatable, CustomStringConvertible {
     /// annotated diagnostics describing every parse error.
     case parseFailed(diagnostics: String)
 
+    /// Two or more requirements would record on the same spy, because they
+    /// derive the same dynamic-member key *and* the same spy signature.
+    case collidingSpyKeys(name: String, requirements: [String])
+
     public var description: String {
         switch self {
         case .noProtocolsFound:
             "no protocol declaration found in input"
         case .parseFailed(let diagnostics):
             "input failed to parse as Swift:\n\(diagnostics)"
+        case .collidingSpyKeys(let name, let requirements):
+            """
+            these requirements would share the spy '\(name)', so stubbing or \
+            verifying one would silently affect the other:
+            \(requirements.map { "  - \($0)" }.joined(separator: "\n"))
+            Rename a parameter or member so their generated spy names differ.
+            """
         }
     }
 }

--- a/Sources/MockableGenerator/MockableGenerator+SpyCollisions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+SpyCollisions.swift
@@ -1,0 +1,138 @@
+//
+//  MockableGenerator+SpyCollisions.swift
+//  swift-mocking
+//
+//  Created by Daniel Cardona on 20/08/25.
+//
+
+import SwiftSyntax
+
+extension MockableGenerator {
+    /// Identifies the spy a requirement records on.
+    ///
+    /// `Mock` stores spies as `[String: [AnySpy]]` and, on lookup, returns the
+    /// first entry under the key whose *type* matches the requested
+    /// `Spy<repeat each Input, Eff, Output>`. Two requirements therefore share a
+    /// spy only when they agree on both halves of this identity — the
+    /// dynamic-member key and the full spy signature. Differing only in
+    /// signature is fine and is how method overloads already coexist.
+    struct SpyIdentity: Hashable {
+        /// The dynamic-member key (`super.<name>`).
+        let name: String
+        /// The spelling of the spy's generic arguments: inputs, effect, output.
+        let signature: String
+    }
+
+    /// A pair of requirements that would record on one shared spy.
+    struct SpyCollision {
+        let identity: SpyIdentity
+        /// Source spellings of the colliding requirements, in declaration order.
+        let requirements: [String]
+    }
+
+    /// Finds requirements that would silently share a spy.
+    ///
+    /// The collision is invisible at runtime: stubbing one member answers calls
+    /// to the other, and verification counts both. Only exact duplicates of
+    /// *both* name and signature are reported — differing signatures under one
+    /// key are a supported overload.
+    static func spyCollisions(in protocolDecl: ProtocolDeclSyntax) -> [SpyCollision] {
+        var seen = [SpyIdentity: [String]]()
+        var order = [SpyIdentity]()
+
+        for member in protocolDecl.memberBlock.members {
+            for identity in spyIdentities(of: member.decl) {
+                if seen[identity.0] == nil {
+                    order.append(identity.0)
+                }
+                seen[identity.0, default: []].append(identity.1)
+            }
+        }
+
+        return order.compactMap { identity in
+            guard let requirements = seen[identity], requirements.count > 1 else {
+                return nil
+            }
+            return SpyCollision(identity: identity, requirements: requirements)
+        }
+    }
+
+    /// The spy identities a single requirement records on, each paired with the
+    /// requirement's source spelling for diagnostics.
+    ///
+    /// A settable requirement contributes two: its read spy and its write spy.
+    private static func spyIdentities(of decl: DeclSyntax) -> [(SpyIdentity, String)] {
+        let spelling = decl.trimmedDescription
+
+        if let funcDecl = decl.as(FunctionDeclSyntax.self) {
+            let inputs = funcDecl.signature.parameterClause.parameters.map { parameter in
+                parameter.ellipsis != nil
+                    ? TypeSyntax(ArrayTypeSyntax(element: parameter.type)).trimmedDescription
+                    : parameter.type.trimmedDescription
+            }
+            let output = funcDecl.signature.returnClause?.type.trimmedDescription ?? "Void"
+            let identity = SpyIdentity(
+                name: funcDecl.name.text,
+                signature: signature(
+                    inputs: inputs,
+                    effect: getFunctionEffectType(funcDecl).rawValue,
+                    output: output
+                )
+            )
+            return [(identity, spelling)]
+        }
+
+        if let varDecl = decl.as(VariableDeclSyntax.self),
+           let binding = varDecl.bindings.first,
+           let type = binding.typeAnnotation?.type {
+            let name = varDecl.name.text
+            let read = SpyIdentity(
+                name: name,
+                signature: signature(inputs: [], effect: "None", output: type.trimmedDescription)
+            )
+            guard varDecl.hasSetter else {
+                return [(read, spelling)]
+            }
+            let write = SpyIdentity(
+                name: name.setterSpyName,
+                signature: signature(
+                    inputs: ["Void", type.trimmedDescription],
+                    effect: "None",
+                    output: "Void"
+                )
+            )
+            return [(read, spelling), (write, spelling)]
+        }
+
+        if let subscriptDecl = decl.as(SubscriptDeclSyntax.self) {
+            let indices = subscriptDecl.parameterClause.parameters.map(\.type.trimmedDescription)
+            let element = subscriptDecl.returnClause.type.trimmedDescription
+            let name = subscriptDecl.name
+            let read = SpyIdentity(
+                name: name,
+                signature: signature(inputs: indices, effect: "None", output: element)
+            )
+            guard subscriptDecl.hasSetter else {
+                return [(read, spelling)]
+            }
+            let write = SpyIdentity(
+                name: name.setterSpyName,
+                signature: signature(
+                    inputs: indices + [element],
+                    effect: "None",
+                    output: "Void"
+                )
+            )
+            return [(read, spelling), (write, spelling)]
+        }
+
+        return []
+    }
+
+    /// Renders a spy's generic arguments, matching how the generated
+    /// `Interaction`/`Spy` types spell an empty input pack as `Void`.
+    private static func signature(inputs: [String], effect: String, output: String) -> String {
+        let inputs = inputs.isEmpty ? ["Void"] : inputs
+        return (inputs + [effect, output]).joined(separator: ", ")
+    }
+}

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -26,6 +26,16 @@ public enum MockableGenerator {
     /// }
     /// ```
     public static func processProtocol(protocolDecl: ProtocolDeclSyntax) throws -> [DeclSyntax] {
+        // Reject requirements that would share a spy before emitting anything:
+        // the resulting mock compiles cleanly but routes both members to one
+        // spy, so stubs and verifications silently cross over.
+        if let collision = spyCollisions(in: protocolDecl).first {
+            throw MockableGeneratorError.collidingSpyKeys(
+                name: collision.identity.name,
+                requirements: collision.requirements
+            )
+        }
+
         let protocolName = protocolDecl.name.text
         let codeGenOptions = MockableGenerator.codeGenOptions(protocolDecl: protocolDecl)
         let mockName: String

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -156,6 +156,68 @@ final class GeneratorPipelineTests: XCTestCase {
         }
     }
 
+    /// Subscript spies are namespaced under a `subscript` prefix, so a method
+    /// and a subscript that would otherwise derive the same name — `index` —
+    /// land on distinct spies and the protocol generates cleanly.
+    func testGenerateMocksNamespacesSubscriptSpiesAwayFromMethods() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable()
+            protocol CollisionService {
+                func index(_ value: Int) -> String
+                subscript(index: Int) -> String { get }
+            }
+            """
+        )
+
+        let source = try XCTUnwrap(mocks.first).source
+        XCTAssertTrue(source.contains("spy: super.index"), source)
+        XCTAssertTrue(source.contains("spy: super.subscriptIndex"), source)
+    }
+
+    /// Argument labels do not reach the spy name, so these two subscripts still
+    /// collide with each other — namespacing separates subscripts from other
+    /// member kinds, not subscripts from one another.
+    func testGenerateMocksThrowsWhenSubscriptsDifferOnlyByArgumentLabel() {
+        XCTAssertThrowsError(
+            try MockableGenerator.generateMocks(
+                source: """
+                @Mockable()
+                protocol CollisionService {
+                    subscript(_ index: Int) -> String { get }
+                    subscript(index: Int) -> String { get }
+                }
+                """
+            )
+        ) { error in
+            guard case let .collidingSpyKeys(name, _) = error as? MockableGeneratorError else {
+                return XCTFail("expected collidingSpyKeys, got \(error)")
+            }
+            XCTAssertEqual(name, "subscriptIndex")
+        }
+    }
+
+    /// Overloads sharing a name but differing in spy signature are supported —
+    /// `Mock` stores a list per key and matches on type — so they must not trip
+    /// the collision check.
+    func testGenerateMocksAllowsOverloadsWithDistinctSpySignatures() throws {
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable()
+            protocol OverloadService {
+                func fetch(_ id: Int) -> String
+                func fetch(_ id: String) -> String
+                func fetch() -> Int
+                subscript(index: Int) -> String { get }
+                subscript(key: String) -> Int { get set }
+                var value: Int { get set }
+            }
+            """
+        )
+
+        XCTAssertEqual(mocks.count, 1)
+    }
+
     func testGenerateMocksWithoutDebugWrapperOmitsIfConfigAndKeepsMembers() throws {
         let mocks = try MockableGenerator.generateMocks(
             source: """


### PR DESCRIPTION
Fifth of a six-PR stack (#105). Based on #102.

Spy names ignore argument labels, so distinct requirements can still collapse onto one key — two subscripts differing only by label derive the same name. When their spy signatures also match, `Mock`'s dynamic-member lookup returns the same spy to both: stubbing one answers calls to the other, and verification counts both. Nothing fails; the test quietly tests the wrong thing.

`processProtocol` now detects this and throws before emitting anything, naming both requirements:

```
error: these requirements would share the spy 'subscriptIndex', so stubbing or
verifying one would silently affect the other:
  - subscript(_ index: Int) -> String { get }
  - subscript(index: Int) -> String { get }
```

Detection is deliberately narrow — **name and signature must both match**. `Mock` stores a list per key and matches on type, so same-name overloads with distinct signatures are a supported feature and must not trip it. Verified against a protocol mixing method overloads, both subscript kinds, and a settable property: no false positive.

Note the `subscript` prefix from #101 already removed the method-vs-subscript case; this covers what naming alone can't fix.

Also drops the `functionNames` dictionary, threaded through `makeInteractions`/`processFunc` but never read.

**Tests:** 218 pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)