### PR TITLE
Document settable requirements and spy naming

### DIFF
--- a/GENERATED_CODE_EXAMPLES.md
+++ b/GENERATED_CODE_EXAMPLES.md
@@ -193,7 +193,7 @@ protocol MyService {
 
 ```swift
 class MockMyService: Mock, @unchecked Sendable, MyService {
-    func value(_ void: Void) -> Interaction<Void, None, Int > {
+    func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
         Interaction(.any, spy: super.value)
     }
 
@@ -206,7 +206,49 @@ class MockMyService: Mock, @unchecked Sendable, MyService {
 ```
 </details>
 
+### Protocol with Settable Property
+
+A settable requirement records reads and writes on two spies (`value` and `setValue`) — their input packs differ, since a write is the read pack plus the written value. One interaction member returns a `SettableInteraction` carrying both.
+
+```swift
+@Mockable
+protocol MyService {
+    var value: Int { get set }
+}
+```
+<details>
+<summary>Generated Code</summary>
+
+```swift
+class MockMyService: Mock, @unchecked Sendable, MyService {
+    func value(_ void: Void = ()) -> SettableInteraction<Void, None, Int > {
+        SettableInteraction(
+            get: Interaction(.any, spy: super.value),
+            setInteraction: { newValue in
+                let writeSpy: Spy<Void, Int, None, Void> = super.setValue
+                let writeInteraction: Interaction<Void, Int, None, Void> = Interaction(.any, newValue, spy: writeSpy)
+                return writeInteraction
+            }
+        )
+    }
+
+        var value: Int {
+        set {
+            return adapt(super.setValue, (), newValue)
+        }
+        get {
+            adapt(super.value, ())
+        }
+    }
+}
+```
+</details>
+
+Usage: `when(mock.value).thenReturn(7)` stubs reads, `verify(mock.value <- 7).called(1)` verifies writes.
+
 ### Protocol with Subscript
+
+The spy name is `subscript` followed by the parameter names in camelCase — `subscript(index:)` → `subscriptIndex`, `subscript(row:column:)` → `subscriptRowColumn`. The prefix keeps subscript spies from colliding with a method or variable of the same name.
 
 ```swift
 @Mockable
@@ -218,20 +260,57 @@ protocol MyService {
 <summary>Generated Code</summary>
 
 ```swift
-class MyServiceMock: Mock, @unchecked Sendable, MyService {
-    subscript(index: Int) -> String {
-        get {
-            return adapt(super.subscript, index)
-        }
-    }
+class MockMyService: Mock, @unchecked Sendable, MyService {
     subscript(index: ArgMatcher<Int>) -> Interaction<Int, None, String > {
         get {
-            Interaction(index, spy: super.subscript)
+            Interaction(index, spy: super.subscriptIndex)
+        }
+    }
+    subscript(index: Int) -> String {
+        get {
+            return adapt(super.subscriptIndex, index)
         }
     }
 }
 ```
 </details>
+
+### Protocol with Settable Subscript
+
+```swift
+@Mockable
+protocol MyService {
+    subscript(index: Int) -> String { get set }
+}
+```
+<details>
+<summary>Generated Code</summary>
+
+```swift
+class MockMyService: Mock, @unchecked Sendable, MyService {
+    subscript(index: ArgMatcher<Int>) -> SettableInteraction<Int, None, String > {
+        get {
+            SettableInteraction(
+                get: Interaction(index, spy: super.subscriptIndex),
+                setInteraction: { newValue in
+                    Interaction(index, newValue, spy: super.setSubscriptIndex)
+                }
+            )
+        }
+    }
+    subscript(index: Int) -> String {
+        set {
+            return adapt(super.setSubscriptIndex, index, newValue)
+        }
+        get {
+            return adapt(super.subscriptIndex, index)
+        }
+    }
+}
+```
+</details>
+
+Usage: `when(mock[.any]).thenReturn("v")` stubs reads, `verify(mock[.equal(1)] <- "v").called(1)` verifies writes.
 
 ### Public Protocol
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,52 @@ verifyInOrder([
 ])
 ```
 
+### Properties and Subscripts
+
+Read-only requirements behave like any other member. **Settable** requirements (`{ get set }`) record reads and writes on two separate spies, because their argument lists differ — a write is the read's arguments plus the assigned value. Both are reached through a single interaction member:
+
+```swift
+@Mockable
+protocol Settings {
+    var isEnabled: Bool { get set }
+    subscript(key: String) -> Int { get set }
+}
+
+let mock = MockSettings()
+
+// Reads — stub and verify exactly like a method
+when(mock.isEnabled).thenReturn(true)
+when(mock[.any]).thenReturn(0)
+
+XCTAssertTrue(mock.isEnabled)
+verify(mock.isEnabled).called(1)
+
+// Writes — the `<-` operator turns the interaction into a write interaction
+mock.isEnabled = false
+mock["retries"] = 3
+
+verify(mock.isEnabled <- false).called(1)
+verify(mock[.equal("retries")] <- 3).called(1)
+verifyNever(mock.isEnabled <- true)
+```
+
+Reads and writes are counted independently: `verify(mock.isEnabled)` counts only reads, and a write never registers as a read.
+
+Because a write records the read's arguments followed by the assigned value, captured arguments and stub closures take the value last:
+
+```swift
+verify(mock[.any] <- .any).captured { key, newValue in
+    XCTAssertEqual(key, "retries")
+    XCTAssertEqual(newValue, 3)
+}
+
+when(mock.isEnabled <- .any).thenReturn { _, newValue in
+    print("isEnabled set to \(newValue)")
+}
+```
+
+Since `<-` yields an ordinary `Interaction`, writes compose with `verifyInOrder` too. One toolchain caveat: for a **multi-index** subscript, bind the write before verifying it — `let write = mock[.equal(1), .equal(2)] <- "v"; verify(write).called(1)` — as forwarding the result directly into `verify` fails to infer.
+
 ### Dynamic Stubbing
 
 
@@ -688,6 +734,26 @@ This approach eliminates the need for manual mock implementations and provides a
 
 In macro-generated mocks, stubbing zero-parameter methods (`when(mock.f()).thenReturn(v)`) and property getters (`when(mock.getX()).thenReturn(v)`) is silently ignored, and verification of those members always counts 0 — a parameter-pack shape mismatch creates a second, disconnected spy. Setters and members with one or more parameters are unaffected. Workaround: hand-write those members with the pinned-spy form documented in the [Agent Skill](#-agent-skill).
 
+
+### Colliding Spy Names
+
+Spies are keyed by a name derived from the requirement: a method uses its own name, a subscript is namespaced as `subscript` + its parameter names in camelCase (`subscript(row:column:)` → `subscriptRowColumn`), and a settable member adds a `set`-prefixed write spy. Argument labels do not contribute.
+
+The subscript prefix means a subscript never collides with a method or variable of the same name. Most ways two requirements could derive the same key are already rejected by the compiler: two subscripts differing only by argument label are an `invalid redeclaration of 'subscript(_:)'`, since subscript labels do not participate in the signature, and a `var value` alongside a `func value()` is an `invalid redeclaration of 'value'`.
+
+The case that compiles but does not mock correctly is two **methods** that differ only by argument label:
+
+```swift
+@Mockable
+protocol CollisionService {
+    func fetch(id: Int) -> String
+    func fetch(name: Int) -> String   // ⚠️ both derive the spy `fetch`
+}
+```
+
+This is legal Swift, but because labels do not reach the spy name and both have the same signature, the two requirements share one spy: stubbing one answers calls to the other, and verification counts both. Nothing fails — the test quietly tests the wrong thing. Workaround: rename one method, or give the parameters distinct types so the spy signatures differ.
+
+Overloads that differ in signature (`func fetch(_ id: Int)` and `func fetch(_ id: String)`) are **not** a collision and work fine — `Mock` stores a list per key and matches on type. A method and a subscript sharing a name (`func index(_:)` alongside `subscript(index:)`) are separated by the prefix.
 
 ### Xcode Autocomplete
 

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -14,6 +14,7 @@ Mocking for Swift protocols: `@Mockable` generates mock classes; `when(...)` stu
 | Protocol has no inheritance; need a mock | `@Mockable protocol P {...}` → use `PMock()` |
 | Protocol inherits another protocol with members | **manual-mocking.md** (macro cannot do this) |
 | Mocking without any protocol (closure/TCA dependencies) | usage.md — `Spy` + `adapt` |
+| Stubbing/verifying settable properties or subscripts (`{ get set }`) | usage.md — *Properties & subscripts*; hand-written shape in manual-mocking.md |
 | Need mock source without the macro (plugin unavailable, codegen, review) | `mockable` CLI (below) when available; hand-writing per manual-mocking.md is always valid |
 | `@Sendable`/Swift 6 concurrency errors when stubbing | sendable.md |
 | Stubbing / matching / verifying API reference | usage.md |
@@ -73,6 +74,8 @@ verify(mock.price(.equal("apple"))).called(1)
 - `@Mockable` on `protocol B: A` → compile error `does not conform to protocol 'A'` (inherited requirements never generated). Hand-write per manual-mocking.md.
 - Zero-arg members (`func start()`, property getters): `when(mock.getX()).thenReturn(v)` does not reach the runtime member in macro-generated mocks. Manual mocks fix this with the pinned-spy pattern.
 - Stub API is `thenReturn` / `thenThrow` / `do` — there is no `.then`.
+- Spy names come from the requirement, ignoring argument labels: methods use their name, subscripts are namespaced as `subscript`+ParameterNames (`subscript(row:column:)` → `subscriptRowColumn`), settable members add `set`+Name. The prefix keeps a subscript from colliding with a method or variable of the same name. The compiler already rejects most same-key cases (two subscripts differing only by argument label, or a `var x` beside a `func x()`, are both invalid redeclarations); the one that compiles but mocks incorrectly is two *methods* differing only by argument label (`fetch(id:)`/`fetch(name:)`), which silently share a spy — rename one or vary the parameter types. Same-name/different-signature overloads are fine.
+- Settable members (`{ get set }`) record reads and writes on **separate spies**: `verify(mock.x)` counts reads, `verify(mock.x <- v)` counts writes. A write never registers as a read.
 - Bare `mock.start()` (zero-arg) is ambiguous on the mock type — call via a protocol-typed reference.
 - **Literal arguments on the mock type dispatch to the interaction member** (`mock.fetchUser(id: "1")` returns an `Interaction` instead of calling through) — call the mock via a protocol-typed reference.
 

--- a/skills/swift-mocking/manual-mocking.md
+++ b/skills/swift-mocking/manual-mocking.md
@@ -96,7 +96,7 @@ public class AuthorizingUserServiceMock: Mock, @unchecked Sendable, AuthorizingU
             let spy: Spy<Void, None, String> = super.cachePolicy
             return spy(())
         }
-        set { return adapt(super.setCachePolicy, newValue) }
+        set { return adapt(super.setCachePolicy, (), newValue) }
     }
     // Runtime — AuthorizingUserService requirements
     public func authorize(_ token: String) throws -> Bool {
@@ -106,11 +106,17 @@ public class AuthorizingUserServiceMock: Mock, @unchecked Sendable, AuthorizingU
     public func fetchUser(id: ArgMatcher<String>) -> Interaction<String, AsyncThrows, User> {
         Interaction(id, spy: super.fetchUser)
     }
-    public func cachePolicy(_ void: Void) -> Interaction<Void, None, String> {
-        Interaction(.any, spy: super.cachePolicy)
-    }
-    public func setCachePolicy(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> {
-        Interaction(newValue, spy: super.setCachePolicy)
+    // Settable → one member returning SettableInteraction (reads + writes)
+    public func cachePolicy(_ void: Void = ()) -> SettableInteraction<Void, None, String> {
+        SettableInteraction(
+            get: Interaction(.any, spy: super.cachePolicy),
+            setInteraction: { newValue in
+                let writeSpy: Spy<Void, String, None, Void> = super.setCachePolicy
+                let writeInteraction: Interaction<Void, String, None, Void> =
+                    Interaction(.any, newValue, spy: writeSpy)
+                return writeInteraction
+            }
+        )
     }
     // Interactions — AuthorizingUserService
     public func authorize(_ token: ArgMatcher<String>) -> Interaction<String, Throws, Bool> {
@@ -126,41 +132,114 @@ Rules:
 
 ## Properties
 
-Getter interaction overloads the variable name with a `Void` parameter; setter is `set` + capitalized name. The `Void` parameter is required, not cosmetic: a niladic `func cachePolicy()` next to the `var cachePolicy` conformance is an `invalid redeclaration` (the property's getter accessor already owns that selector), and the unapplied reference `mock.cachePolicy` must have exactly type `(Void) -> Interaction<…>` for `when(mock.cachePolicy)` / `verify(mock.cachePolicy)` to infer their input pack.
+Getter interaction overloads the variable name with a `Void` parameter. The `Void` parameter is required, not cosmetic: a niladic `func cachePolicy()` next to the `var cachePolicy` conformance is an `invalid redeclaration` (the property's getter accessor already owns that selector), and the unapplied reference `mock.cachePolicy` must have exactly type `(Void) -> Interaction<…>` — or `(Void) -> SettableInteraction<…>` for a settable property, which `when`/`verify` accept through their own overloads — for `when(mock.cachePolicy)` / `verify(mock.cachePolicy)` to infer their input pack.
+
+**Read-only** property → runtime getter + the `x(_ void: Void)` interaction returning a plain `Interaction`:
+
+```swift
+// protocol: var readOnly: Int { get }
+var readOnly: Int {
+    get {
+        // Pass () explicitly — a bare `adapt(super.readOnly)` hits the
+        // zero-arg spy mismatch and getter stubs/verifies silently no-op.
+        adapt(super.readOnly, ())
+    }
+}
+func readOnly(_ void: Void) -> Interaction<Void, None, Int> {
+    Interaction(.any, spy: super.readOnly)
+}
+```
+
+**Settable** property → reads and writes record on *two* spies (`cachePolicy` and `setCachePolicy`), because their input packs differ. One interaction member returns a `SettableInteraction` carrying both:
 
 ```swift
 // protocol: var cachePolicy: String { get set }
 var cachePolicy: String {
-    get {
-        // Pass () explicitly — a bare `adapt(super.cachePolicy)` hits the
-        // zero-arg spy mismatch and getter stubs/verifies silently no-op.
-        adapt(super.cachePolicy, ())
-    }
-    set { return adapt(super.setCachePolicy, newValue) }
+    get { adapt(super.cachePolicy, ()) }
+    // The `return` pins Output == Void; see the errors table.
+    set { return adapt(super.setCachePolicy, (), newValue) }
 }
-func cachePolicy(_ void: Void) -> Interaction<Void, None, String> {
-    Interaction(.any, spy: super.cachePolicy)
-}
-func setCachePolicy(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> {
-    Interaction(newValue, spy: super.setCachePolicy)
+func cachePolicy(_ void: Void = ()) -> SettableInteraction<Void, None, String> {
+    SettableInteraction(
+        get: Interaction(.any, spy: super.cachePolicy),
+        setInteraction: { newValue in
+            let writeSpy: Spy<Void, String, None, Void> = super.setCachePolicy
+            // Both locals are explicitly typed: the pack `(repeat each Input, Output)`
+            // cannot be split back out by inference on Swift 5.9/6.0.
+            let writeInteraction: Interaction<Void, String, None, Void> =
+                Interaction(.any, newValue, spy: writeSpy)
+            return writeInteraction
+        }
+    )
 }
 ```
 
-Read-only property → runtime getter + the `x(_ void: Void)` interaction only.
+Three details the compiler will not catch for you:
+
+1. **Write spy name is `set` + the name with only its first letter uppercased** — `setCachePolicy`, not `setCachepolicy`. Read and write sides must agree; if both are wrong in the same way tests still pass, so this only shows up as a typo in your source.
+2. **The write pack is the read pack plus the value**: the setter passes `(), newValue` and the write `Interaction` lists `.any, newValue`. Getting the order wrong misroutes matchers silently.
+3. **`setInteraction` is a closure**, not a stored `Interaction` — appending a value after a pack expansion isn't expressible in a generic body, so generated and hand-written mocks both inject it.
 
 ## Subscripts
+
+Spy name is `subscript` followed by the parameter names in camelCase — `subscript(key:)` → `subscriptKey`, `subscript(row:column:)` → `subscriptRowColumn`; a subscript with no named parameter is just `subscript`. Write spy is `set` + that name upper-camel-cased (`setSubscriptRowColumn`). The prefix is what keeps a subscript's spy distinct from a method or variable sharing the name.
 
 ```swift
 // protocol: subscript(key: String) -> Int { get }
 subscript(key: String) -> Int {
-    get { return adapt(super.subscript, key) }
+    get { return adapt(super.subscriptKey, key) }
 }
 subscript(key: ArgMatcher<String>) -> Interaction<String, None, Int> {
-    get { Interaction(key, spy: super.subscript) }
+    get { Interaction(key, spy: super.subscriptKey) }
 }
 ```
 
-Spy key is always the literal member name `subscript`. Usage: `when(mock[.any]).thenReturn(1)`.
+**Settable** subscript — same two-spy structure as a settable property, with the indices in place of the property's `(Void)` pack:
+
+```swift
+// protocol: subscript(key: String) -> Int { get set }
+subscript(key: String) -> Int {
+    get { return adapt(super.subscriptKey, key) }
+    set { return adapt(super.setSubscriptKey, key, newValue) }
+}
+subscript(key: ArgMatcher<String>) -> SettableInteraction<String, None, Int> {
+    get {
+        SettableInteraction(
+            get: Interaction(key, spy: super.subscriptKey),
+            setInteraction: { newValue in
+                let writeSpy: Spy<String, Int, None, Void> = super.setSubscriptKey
+                return Interaction(key, newValue, spy: writeSpy)
+            }
+        )
+    }
+}
+```
+
+Usage: `when(mock[.any]).thenReturn(1)` stubs reads; `verify(mock[.equal("k")] <- 9).called(1)` verifies writes.
+
+## Testing settable members
+
+Reads and writes are **separate spies** — a write never registers as a read.
+
+```swift
+let mock = ConfigMock()
+when(mock.cachePolicy).thenReturn("none")          // stub the read
+
+XCTAssertEqual(mock.cachePolicy, "none")           // property: no indirection needed
+mock.cachePolicy = "aggressive"                    // routes to the write spy
+
+verify(mock.cachePolicy).called(1)                 // reads only
+verify(mock.cachePolicy <- "aggressive").called(1) // writes only
+verifyNever(mock.cachePolicy <- .equal("never"))
+```
+
+For a **property**, the runtime member is a `var` and the interaction member is a `func`, so both directions resolve unambiguously on the mock type — drive it directly. **Subscript reads** are the exception: `mock[key]` and `mock[.any]` are a real overload pair, so bind `let svc: Config = mock` and read through it (writes are fine either way). Zero-arg **methods** always need the protocol type.
+
+- **Captured values put the written value last**, after the read pack: `verify(mock.cachePolicy <- .any).captured { _, newValue in ... }` — the `_` is the property's `(Void)` read pack.
+- **Write side effects**: `when(mock.value <- 7).thenReturn { _, newValue in ... }`.
+- **`verifyInOrder` composes**, since `<-` yields an ordinary `Interaction`: `verifyInOrder([mock.cachePolicy <- "aggressive", mock[.any] <- 9])`.
+- **Multi-index subscripts must bind first** — `let w = mock[.equal(1), .equal(2)] <- "x"; verify(w).called(1)`. Forwarding a pack-rearranged result directly into `verify` does not infer on current toolchains; single-index subscripts and properties are fine.
+- Explicit alternative to the operator: `mock.cachePolicy(()).set(.equal("aggressive"))`, `mock[.any].set(.any)`.
 
 ## Variadic parameters
 
@@ -240,7 +319,9 @@ func execute(completion: ArgMatcher<(String) -> Void>) -> Interaction<(String) -
 | Zero-arg runtime member written as `adapt(super.f)` | Stub ignored; `verify(...)` always 0 (silent) | Pass `()`: `adapt(super.f, ())` — the form the macro emits |
 | Calling `mock.f()` bare on a zero-arg mock member | `ambiguous use of 'f()'` | Call through a protocol-typed reference |
 | Getter body `adapt(super.getX)` (wrong key or bare adapt) | Getter stubs/verifies silently no-op | Pin `Spy<Void, None, T>` keyed by the **property name** |
-| Setter body without `return` | `generic parameter 'Output' could not be inferred` | `set { return adapt(super.setX, newValue) }` — the `return` pins `Output == Void` |
+| Setter body without `return` | `generic parameter 'Output' could not be inferred` | `set { return adapt(super.setCachePolicy, (), newValue) }` — the `return` pins `Output == Void` |
+| Write verified but count is 0 | — | Read/write spy names disagree (e.g. setter uses `.capitalized` → `setCachepolicy` while the interaction uses `setCachePolicy`) |
+| `verify(mock[.a, .b] <- v)` won't compile | `cannot convert value` / inference failure | Multi-index subscript: bind first (`let w = mock[.a, .b] <- v`), then `verify(w)` |
 | Only implementing the derived protocol's members | Compile error (missing runtime witnesses) | Flatten the chain — runtime + interaction members for every ancestor requirement |
 | Runtime members only (no `ArgMatcher` overloads) | Compiles; `when`/`verify` can't reference the method | Every requirement gets both members |
 | Instantying `Spy()` manually inside the mock | Invocations not recorded where `when`/`verify` look | Always go through `super.<name>` |

--- a/skills/swift-mocking/usage.md
+++ b/skills/swift-mocking/usage.md
@@ -57,16 +57,40 @@ verifyInOrder([mock.auth(.any), mock.data(.any)])  // call order across spies
 
 ## Properties & subscripts
 
-```swift
-when(mock.isEnabled).thenReturn(true)       // getter interaction — reads like the property itself
-mock.isEnabled = false
-verify(mock.setIsEnabled(newValue: .equal(false))).called(1)
+Read-only members expose a plain `Interaction`. **Settable** members (`{ get set }`) expose a `SettableInteraction`: the same expression stubs/verifies reads, and `<- value` turns it into the write interaction.
 
-when(cache[.any]).thenReturn("cached")       // subscript interactions via matcher subscript
-verify(cache[.equal("key")]).called(1)
+```swift
+let mock = MyServiceMock()
+let svc: MyService = mock                    // protocol-typed reference, for subscript reads
+
+// Reads — unchanged by settability
+when(mock.isEnabled).thenReturn(true)        // property getter
+when(mock[.any]).thenReturn("cached")        // subscript getter
+verify(mock.isEnabled).called(1)
+verify(mock[.equal("key")]).called(1)
+
+// Writes — `<-` on the same expression
+mock.isEnabled = false                       // properties: drive the mock directly
+svc["key"] = "v"                             // subscripts: via the protocol-typed `svc`
+verify(mock.isEnabled <- false).called(1)
+verify(mock[.equal("key")] <- "v").called(1)
+verifyNever(mock.isEnabled <- .any)
 ```
 
-Getter verification mirrors a read too: `verify(mock.isEnabled).called(1)` (also `verifyNever(mock.isEnabled)`). The getter interaction is an overload on the variable name taking `Void` — the parameter is required: a niladic form would be an `invalid redeclaration` against the property's getter accessor, and it's what lets `when(mock.x)` infer its input pack. Setter interactions keep the `setX(newValue:)` form. Bare zero-arg calls (`mock.f()`) on the mock type can be ambiguous between the runtime and interaction members — call through the protocol type.
+Rules that trip people up:
+
+- **Reads and writes are separate spies.** `verify(mock.isEnabled)` counts reads only; `verify(mock.isEnabled <- .any)` counts writes only. A write does not register as a read.
+- **Properties need no protocol-typed reference.** The runtime member is a `var` and the interaction member is a `func`, so `mock.isEnabled = false` and `_ = mock.isEnabled` both hit the property while `when(mock.isEnabled)` still resolves to the interaction. Tests read better driving the mock directly.
+- **Subscripts do need one for reads.** `mock[key]` (values) and `mock[.any]` (matchers) are a genuine overload pair — an unannotated `let v = mock[1]` is ambiguous. Use a protocol-typed reference (`let svc: MyService = mock`) for reads; writes (`mock["k"] = 5`) disambiguate on their own.
+- **Zero-arg methods always need one.** `mock.refresh()` is ambiguous between runtime and interaction members.
+- **The write pack is the read pack plus the written value** — so `captured` and stub closures take the indices first, value last: `verify(mock.isEnabled <- .any).captured { _, newValue in ... }`. For a property the read pack is `(Void)`, hence the leading `_`.
+- **Matchers work on both sides**: `verify(cache[.any] <- .equal("v"))`, `mock.count <- .greaterThan(8)`. Bare literals coerce to `.equal`.
+- **Stub write side effects** with `when(mock.value <- 7).thenReturn { _, newValue in ... }`. Handlers are `@Sendable`, so collect what they observe in a `CaptureBox<T>` (from `SwiftMockingTestSupport`) rather than a captured local `var`: `written.append(newValue)` then assert on `written.values`.
+- `<-` composes with `verifyInOrder`, since it yields an ordinary `Interaction`: `verifyInOrder([mock.value <- 7, mock.refresh()])`.
+- **Multi-index subscripts must bind first** — `let w = mock[.equal(1), .equal(2)] <- "x"; verify(w).called(1)`. Forwarding the pack-rearranged result straight into `verify` does not infer on current toolchains. Single-index subscripts and properties chain fine.
+- Explicit form if you prefer it over the operator: `mock.value(()).set(.equal(7))`, `mock[.any].set(.any)`.
+
+The getter interaction is an overload on the variable name taking `Void` — the parameter is required: a niladic form would be an `invalid redeclaration` against the property's getter accessor, and it's what lets `when(mock.x)` infer its input pack. Bare zero-arg calls (`mock.f()`) on the mock type can be ambiguous between the runtime and interaction members — call through the protocol type.
 
 ## Closure-based dependencies (TCA pattern)
 


### PR DESCRIPTION
Docs only — no code changes. Based on `main`.

**README** gains a *Properties and Subscripts* usage section (reads, `<-` writes, the separate read/write spies, value-last capture order, the multi-index bind-first caveat) and a *Colliding Spy Names* entry under Known Limitations. The feature table claimed Variables ✅ and Subscripts ✅ but had no example for either. The whole snippet was compiled and run as a test before being committed.

**GENERATED_CODE_EXAMPLES.md** adds settable property and settable subscript expansions, and corrects the read-only subscript sample, which showed `adapt(super.subscript, index)` — a spy name that stopped being accurate several renames ago. All three samples verified byte-identical to `mockable` output.

**Agent skill** taught `verify(mock.setIsEnabled(newValue:))`, which no longer exists. `usage.md` and `manual-mocking.md` now cover `SettableInteraction`, `<-`, the two-spy split, and the hand-written shape; every code sample was compiled and run.

The design/plan docs under `docs/` from the original branch are intentionally **not** included — they describe the superseded `assigned:` API and are historical planning records.

**On spy-name collisions:** an earlier version of this stack (#103) added an expansion-time diagnostic for these. That was dropped — the compiler already rejects the cases it targeted (two subscripts differing only by argument label are an `invalid redeclaration of 'subscript(_:)'`; a `var x` beside a `func x()` likewise). The one case that compiles but mocks incorrectly — two methods differing only by argument label, which silently share a spy — is now documented as a known limitation instead.

**Tests:** 215 pass, plus the Examples package.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance and examples for mocking settable properties and subscripts.
  - Documented independent read and write stubbing, verification, argument capture, closures, side effects, and interaction ordering.
  - Added support details for multi-index subscripts, matcher usage, and direct write syntax.
  - Expanded guidance on spy naming, overloads, collisions, common mistakes, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->