### PR TITLE
Fix indentation for variable requirement expansions

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -86,10 +86,13 @@ extension MockableGenerator {
     /// For a variable `var value: Int { get }`, this will generate a computed property with a getter that calls the mock's `adapt` function.
     static func variableRequirement(_ variableDecl: VariableDeclSyntax) -> VariableDeclSyntax {
         return VariableDeclSyntax(
-            leadingTrivia: .newline,
             attributes: variableDecl.attributes,
             modifiers: variableDecl.modifiers.trimmed,
-            bindingSpecifier: variableDecl.bindingSpecifier,
+            // Trimmed so the `var` keyword does not carry the protocol's source
+            // indentation: BasicFormat infers a block's indentation by *adding*
+            // the first token's existing leading trivia to the enclosing level,
+            // which would double-indent the generated property.
+            bindingSpecifier: variableDecl.bindingSpecifier.trimmed,
             bindings: PatternBindingListSyntax {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -50,8 +50,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
-
-                    var value: Int {
+                var value: Int {
                     get {
                         adapt(super.value, ())
                     }

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -53,8 +53,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                 func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
-
-                    var value: Int {
+                var value: Int {
                     get {
                         adapt(super.value, ())
                     }
@@ -91,8 +90,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         }
                     )
                 }
-
-                    var value: Int {
+                var value: Int {
                     set {
                         return adapt(super.setValue, (), newValue)
                     }
@@ -135,8 +133,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         }
                     )
                 }
-
-                    var cachePolicy: String {
+                var cachePolicy: String {
                     set {
                         return adapt(super.setCachePolicy, (), newValue)
                     }


### PR DESCRIPTION
## Problem

Mocks generated for `var` protocol requirements came out mis-indented — the `var` line sat 4 spaces too deep, with a stray blank line above it and accessors that looked un-nested relative to their own declaration:

```swift
class MockMyService: Mock, @unchecked Sendable, MyService {
    func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
        Interaction(.any, spy: super.value)
    }

        var value: Int {     // ← 8 spaces, and a stray blank line
        get {
            adapt(super.value, ())
        }
    }
}
```

## Root cause

`variableRequirement` reused the protocol's `bindingSpecifier` token verbatim, so the `var` keyword carried the 4 spaces of leading trivia from the original protocol source.

SwiftSyntax's `BasicFormat` infers a block's indentation by *adding* the first token's existing leading trivia to the enclosing level (`lastNonUserDefinedIndentation + tokenIndentation` in `visitPre`). The copied 4 spaces were therefore added on top of the formatter's own 4, yielding 8.

Only variables were affected: the adjacent `modifiers` argument was already `.trimmed`, and the subscript/function/initializer paths build their tokens fresh.

## Fix

Two changes in `variableRequirement`:

- Trim the binding specifier (`variableDecl.bindingSpecifier.trimmed`), with a comment explaining the `BasicFormat` behavior so it isn't "cleaned up" later.
- Drop the `leadingTrivia: .newline`, which produced the stray blank line and was inconsistent with how every other requirement is emitted.

```swift
    }
    var value: Int {
        get {
            adapt(super.value, ())
        }
    }
```

## Tests

Updated the fixtures that had pinned the malformed output:

- Three inline snapshots in `ProtocolFeaturesTests.swift` (getter, settable, multi-word settable), re-recorded.
- The hand-written expectation in `GeneratorPipelineTests.swift`, which pinned the same bad output for the `mockable` CLI pipeline.

Verified: full suite 215 tests / 0 failures; Examples 19 tests / 0 failures.

## Note

`MacroTestCase.swift` hardcodes `record: false`, which overrides the `SNAPSHOT_TESTING_RECORD` env var — re-recording requires editing that line temporarily. Left as-is in this PR, but worth revisiting if snapshot re-recording comes up often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated mock properties to use consistent indentation and formatting.
  * Prevented duplicated indentation in generated property declarations.

* **Tests**
  * Updated generated-code expectations to reflect corrected formatting for read-only and settable properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->