### PR TITLE
Add spacing between generated members

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -73,7 +73,10 @@ extension MockableGenerator {
     static func functionRequirement(_ functionDecl: FunctionDeclSyntax) -> FunctionDeclSyntax {
         return FunctionDeclSyntax(
             attributes: functionDecl.attributes,
-            modifiers: functionDecl.modifiers,
+            // Trimmed because modifiers copied from the protocol carry the
+            // source's leading trivia; that stale newline and indentation would
+            // otherwise survive into the generated member and misindent it.
+            modifiers: functionDecl.modifiers.trimmed,
             name: functionDecl.name,
             genericParameterClause: functionDecl.genericParameterClause,
             signature: functionDecl.signature,

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -46,10 +46,8 @@ public enum MockableGenerator {
         let interactions = makeInteractions(protocolDecl: protocolDecl)
         let conformanceRequirements = makeConformanceRequirements(for: protocolDecl)
 
-        var members = [MemberBlockItemSyntax]()
-        members.append(contentsOf: typeAliases.map { MemberBlockItemSyntax(decl: $0) })
-        members.append(contentsOf: interactions.map { MemberBlockItemSyntax(decl: $0) })
-        members.append(contentsOf: conformanceRequirements.map { MemberBlockItemSyntax(decl: $0) })
+        let members = separatedByBlankLines(typeAliases + interactions + conformanceRequirements)
+            .map { MemberBlockItemSyntax(decl: $0) }
 
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
@@ -88,6 +86,26 @@ public enum MockableGenerator {
         })
 
         return [DeclSyntax(ifConfigDecl)]
+    }
+
+    /// Inserts a blank line before every member but the first.
+    ///
+    /// Members come from three independent builders (type aliases,
+    /// interactions, conformance requirements), none of which knows what
+    /// precedes it, so separation is applied once here where the whole list is
+    /// known.
+    ///
+    /// The newline goes on the member's *first token* rather than on the
+    /// enclosing `MemberBlockItemSyntax`, because that is the trivia
+    /// `BasicFormat` reads: it prepends a newline only when the token does not
+    /// already start with one, and re-indents whatever newlines it finds. A
+    /// newline parked on the member block item instead lands ahead of the
+    /// declaration's own indentation and leaves the line misindented.
+    static func separatedByBlankLines(_ decls: [DeclSyntax]) -> [DeclSyntax] {
+        decls.enumerated().map { index, decl in
+            guard index > 0 else { return decl }
+            return DeclSyntax(decl.with(\.leadingTrivia, .newlines(2) + decl.leadingTrivia))
+        }
     }
 
     /// Checks if a protocol has any static members.

--- a/Tests/SwiftMockingMacrosTests/BasicTests.swift
+++ b/Tests/SwiftMockingMacrosTests/BasicTests.swift
@@ -24,6 +24,7 @@ final class BasicTests: MacroTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) -> Int {
                     return adapt(super.price, item)
                 }

--- a/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
+++ b/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
@@ -24,6 +24,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) -> Int {
                     return adapt(super.price, item)
                 }
@@ -52,6 +53,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func print(_ values: ArgMatcher<String>...) -> Interaction<[String], None, Void> {
                     Interaction(.variadic(values), spy: super.print)
                 }
+
                 func print(_ values: String...) {
                     return adapt(super.print, values)
                 }
@@ -80,6 +82,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Throws, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) throws -> Int {
                     return try adaptThrowing(super.price, item)
                 }
@@ -108,6 +111,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, Async, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) async -> Int {
                     return await adapt(super.price, item)
                 }
@@ -136,6 +140,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, AsyncThrows, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) async throws -> Int {
                     return try await adaptThrowing(super.price, item)
                 }
@@ -166,12 +171,15 @@ final class FunctionSignatureTests: MacroTestCase {
                 func fetch(from url: ArgMatcher<URL>) -> Interaction<URL, AsyncThrows, Data> {
                     Interaction(url, spy: super.fetch)
                 }
+
                 func post(to url: ArgMatcher<URL>, data: ArgMatcher<Data>) -> Interaction<URL, Data, AsyncThrows, Void> {
                     Interaction(url, data, spy: super.post)
                 }
+
                 func fetch(from url: URL) async throws -> Data {
                     return try await adaptThrowing(super.fetch, url)
                 }
+
                 func post(to url: URL, data: Data) async throws {
                     return try await adaptThrowing(super.post, url, data)
                 }
@@ -200,6 +208,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func doSomething() -> Interaction<Void, None, String> {
                     Interaction(.any, spy: super.doSomething)
                 }
+
                 func doSomething() -> String {
                     return adapt(super.doSomething, ())
                 }
@@ -228,6 +237,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func doSomething(with value: ArgMatcher<Int>) -> Interaction<Int, None, Void> {
                     Interaction(value, spy: super.doSomething)
                 }
+
                 func doSomething(with value: Int) {
                     return adapt(super.doSomething, value)
                 }
@@ -256,6 +266,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
+
                 func doSomething() {
                     return adapt(super.doSomething, ())
                 }
@@ -285,7 +296,8 @@ final class FunctionSignatureTests: MacroTestCase {
                 static func log(_ message: ArgMatcher<String>) -> Interaction<String, None, Void> {
                     Interaction(message, spy: super.log)
                 }
-                    static func log(_ message: String) {
+
+                static func log(_ message: String) {
                     return adapt(super.log, message)
                 }
             }
@@ -314,6 +326,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func logEvent<E: Identifiable>(_ event: ArgMatcher<E>) -> Interaction<E, None, Bool> {
                     Interaction(event, spy: super.logEvent)
                 }
+
                 func logEvent<E: Identifiable>(_ event: E) -> Bool {
                     return adapt(super.logEvent, event)
                 }
@@ -342,6 +355,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 func execute(completion: ArgMatcher<(String) -> Void>) -> Interaction<(String) -> Void, None, Void> {
                     Interaction(completion, spy: super.execute)
                 }
+
                 func execute(completion: @escaping (String) -> Void) {
                     return adapt(super.execute, completion)
                 }

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -24,6 +24,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) -> Int {
                     return adapt(super.price, item)
                 }
@@ -50,6 +51,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
+
                 var value: Int {
                     get {
                         adapt(super.value, ())
@@ -78,6 +80,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
+
                 func doSomething() {
                     return adapt(super.doSomething, ())
                 }
@@ -172,6 +175,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) -> Int {
                     return adapt(super.price, item)
                 }

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -24,6 +24,7 @@ final class MacroOptionsTests: MacroTestCase {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
+
                 func doSomething() {
                     return adapt(super.doSomething, ())
                 }
@@ -52,6 +53,7 @@ final class MacroOptionsTests: MacroTestCase {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
+
                 func doSomething() {
                     return adapt(super.doSomething, ())
                 }

--- a/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
@@ -28,6 +28,7 @@ final class MockableMacroTests: MacroTestCase {
                 func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
                     Interaction(item, spy: super.price)
                 }
+
                 func price(_ item: String) -> Int {
                     return adapt(super.price, item)
                 }

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -25,6 +25,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                 func doSomething() -> Interaction<Void, None, Void> {
                     Interaction(.any, spy: super.doSomething)
                 }
+
                 func doSomething() {
                     return adapt(super.doSomething, ())
                 }
@@ -53,6 +54,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                 func value(_ void: Void = ()) -> Interaction<Void, None, Int > {
                     Interaction(.any, spy: super.value)
                 }
+
                 var value: Int {
                     get {
                         adapt(super.value, ())
@@ -90,6 +92,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         }
                     )
                 }
+
                 var value: Int {
                     set {
                         return adapt(super.setValue, (), newValue)
@@ -133,6 +136,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         }
                     )
                 }
+
                 var cachePolicy: String {
                     set {
                         return adapt(super.setCachePolicy, (), newValue)
@@ -192,6 +196,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         Interaction(index, spy: super.subscriptIndex)
                     }
                 }
+
                 subscript(index: Int) -> String {
                     get {
                         return adapt(super.subscriptIndex, index)
@@ -231,6 +236,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         )
                     }
                 }
+
                 subscript(index: Int) -> String {
                     set {
                         return adapt(super.setSubscriptIndex, index, newValue)
@@ -269,6 +275,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         Interaction(item, spy: super.subscriptItem)
                     }
                 }
+
                 subscript <T: Hashable>(item: T) -> String {
                     get {
                         return adapt(super.subscriptItem, item)
@@ -301,6 +308,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         Interaction(row, column, spy: super.subscriptRowColumn)
                     }
                 }
+
                 subscript(row: Int, column: Int) -> String {
                     get {
                         return adapt(super.subscriptRowColumn, row, column)
@@ -333,6 +341,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                         Interaction(position, spy: super.subscriptPosition)
                     }
                 }
+
                 subscript(_ position: Int) -> String {
                     get {
                         return adapt(super.subscriptPosition, position)
@@ -363,9 +372,11 @@ final class ProtocolFeaturesTests: MacroTestCase {
             #if DEBUG
             class MockMyService<Item>: Mock, @unchecked Sendable, MyService {
                 typealias Item = Item
+
                 func item() -> Interaction<Void, None, Item> {
                     Interaction(.any, spy: super.item)
                 }
+
                 func item() -> Item {
                     return adapt(super.item, ())
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and indentation in generated mock code for clearer, more consistent output.
  * Added blank lines between generated methods, properties, type aliases, and conformance sections.

* **Bug Fixes**
  * Prevented inherited formatting from affecting indentation in generated protocol conformances.

* **Tests**
  * Updated generation snapshots to verify the revised formatting across supported protocol features and naming options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->