### PR TITLE
Raise tvos min target and fix wasm build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,9 +32,9 @@ let package = Package(
     platforms: [
         .macOS(.v14),
         .iOS(.v17),
-        .tvOS(.v13),
+        .tvOS(.v17),
         .watchOS(.v10),
-        .macCatalyst(.v13)
+        .macCatalyst(.v17)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -64,7 +64,6 @@ let package = Package(
             dependencies: [
                 "SwiftMockingMacros",
                 "SwiftMockingOptions",
-                "MockableGenerator",
                 .product(name: "IssueReporting", package: "xctest-dynamic-overlay")
             ],
             swiftSettings: swiftSettings + interfaceSettings

--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,10 @@ let package = Package(
             dependencies: [
                 "SwiftMockingMacros",
                 "SwiftMockingOptions",
+                // Not imported by any source file here, but `@Mockable` expansions in
+                // client targets reference MockableGenerator symbols, which xcodebuild
+                // only resolves if the dependency is declared on this target.
+                "MockableGenerator",
                 .product(name: "IssueReporting", package: "xctest-dynamic-overlay")
             ],
             swiftSettings: swiftSettings + interfaceSettings

--- a/Sources/SwiftMockingTestSupport/MockingTestCase.swift
+++ b/Sources/SwiftMockingTestSupport/MockingTestCase.swift
@@ -1,4 +1,6 @@
-#if canImport(XCTest)
+// WASI ships an XCTest module whose members are all marked unavailable, so
+// `canImport(XCTest)` succeeds there while `invokeTest()` cannot be overridden.
+#if canImport(XCTest) && !os(WASI)
 import XCTest
 import SwiftMocking
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Platform Support**
  * Increased the minimum supported versions for tvOS and Mac Catalyst to 17.
  * Improved compatibility for WASI environments by excluding unsupported XCTest functionality.

* **Maintenance**
  * Removed an unnecessary mocking code-generation dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->