### PR TITLE
Link IssueReportingTestSupport and bump reporting dependency

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "209afe494bc42c2f01ec147045d99ff2688bd12e600e6a6847afd8c8d76958ea",
+  "originHash" : "ef2f5cf220115fda3b40272e5055b266a5d07d38ae801caf39892fb84a2a97dd",
   "pins" : [
     {
       "identity" : "swift-syntax",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23e3442166b5122f73f9e3e622cd1e4bafeab3b7",
-        "version" : "1.6.0"
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
             targets: ["Examples"]),
     ],
     dependencies: [
-        .package(path: "../")
+        .package(path: "../"),
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.11.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -32,7 +33,10 @@ let package = Package(
         ),
         .testTarget(
             name: "ExamplesTests",
-            dependencies: ["Examples"]
+            dependencies: [
+                "Examples",
+                .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
+            ]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -53,9 +53,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"602.0.0"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.3"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.7.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.5"),
-        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.6.0")
+        // NOTE: This is the pre-2.0 name of swift-issue-reporting. Migrating to
+        // `https://github.com/pointfreeco/swift-issue-reporting` (2.x) currently fails
+        // the package graph: swift-custom-dump — reached via swift-macro-testing ->
+        // swift-snapshot-testing, and still on the old name as of custom-dump 1.7.0 and
+        // its main branch — makes SwiftPM see two distinct packages vending an
+        // `IssueReporting` target. The two URLs are separate live repos, not a redirect,
+        // so SwiftPM cannot unify them. Revisit once custom-dump adopts the new name.
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.11.0")
 
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -118,6 +118,7 @@ let package = Package(
             dependencies: [
                 "SwiftMocking",
                 "SwiftMockingTestSupport",
+                .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),


### PR DESCRIPTION
## What

Bumps `xctest-dynamic-overlay` to 1.11.0 and links its `IssueReportingTestSupport` product into the test targets of both the main package and Examples.

## Why

Without that product linked, `IssueReporting` cannot resolve `_$s25IssueReportingTestSupport07_recordA0ypyF` and falls back to a `DEBUG`-only path that `unsafeBitCast`s dynamically looked-up symbols. Under swift-testing that path **segfaults**: a bare `reportIssue("...")` inside an `@Test` crashes the process before any failure is recorded.

Reproduced on pristine sources, so this is independent of any other change in flight:

```swift
@Test func bareReportIssue() {
    reportIssue("plain message")   // signal 11
}
```

Consumers of SwiftMocking need the same dependency in their own test targets — worth noting in docs separately.

Examples gains a direct dependency on the package because it previously reached SwiftMocking only through `.package(path: "../")`, which does not expose sibling products.

## Notes

Migrating to `swift-issue-reporting` 2.x is **blocked**: `swift-custom-dump` (via swift-macro-testing → swift-snapshot-testing) still declares the old package name, so SwiftPM sees two packages vending an `IssueReporting` target and refuses the graph. The two URLs are separate live repos, not a redirect. Revisit once custom-dump adopts the new name.

## Testing

215 tests pass. This PR is independent of the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test support for example and mocking test suites.
  * Improved compatibility with newer testing package versions.
* **Chores**
  * Updated package requirements and dependencies.
  * Documented a package naming conflict affecting issue-reporting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->