### PR TITLE
Name the method and recorded invocations in failure messages

### DIFF
--- a/Sources/SwiftMocking/Assert.swift
+++ b/Sources/SwiftMocking/Assert.swift
@@ -57,7 +57,38 @@ public class Assert<each Input, Eff: Effect, Output> {
         let countMatcher = matcher ?? .greaterThan(.zero)
         let count = if let invocationMatcher { spy.invocationCount(matching: invocationMatcher) } else { spy.invocations.count }
         if !countMatcher(count) {
-            throw MockingError.unfulfilledCallCount(count)
+            throw MockingError.unfulfilledCallCount(
+                count,
+                expected: Self.describeExpectation(matcher),
+                method: spy.methodLabel,
+                recorded: recordedDescriptions()
+            )
+        }
+    }
+
+    /// Describes the expected call count for the failure message.
+    ///
+    /// ``ArgMatcher`` wraps an opaque predicate, so a caller-supplied matcher cannot be
+    /// rendered — probing it at sample counts would risk naming an expectation the user
+    /// never expressed. Only the implicit default is described, since that is the one
+    /// expectation absent from the test source.
+    private static func describeExpectation(_ matcher: ArgMatcher<Int>?) -> String? {
+        matcher == nil ? "at least 1 call" : nil
+    }
+
+    /// Renders every invocation recorded on the spy, marking which ones matched.
+    ///
+    /// The full list is shown rather than only the matches: a verification usually fails
+    /// *because* the recorded arguments differ from the expected ones, and that difference
+    /// is invisible if non-matching invocations are filtered out.
+    func recordedDescriptions() -> [String] {
+        let all = spy.invocations
+        guard let invocationMatcher else {
+            return all.map { $0.debugDescription }
+        }
+        return all.map { invocation in
+            let matched = invocationMatcher.isMatchedBy(invocation)
+            return "\(invocation.debugDescription)\(matched ? " (matched)" : "")"
         }
     }
 
@@ -84,7 +115,10 @@ public class Assert<each Input, Eff: Effect, Output> {
     func captures(_ inspector: @escaping (repeat each Input) throws -> Void) throws {
         let matchingInvocations = getMatchingInvocations()
         guard !matchingInvocations.isEmpty else {
-            throw MockingError.noMatchingInvocations
+            throw MockingError.noMatchingInvocations(
+                method: spy.methodLabel,
+                recorded: recordedDescriptions()
+            )
         }
         
         for invocation in matchingInvocations {
@@ -143,11 +177,11 @@ extension Assert where Eff == Throws {
         }
 
         if errors.isEmpty {
-            throw MockingError.didNotThrow
+            throw MockingError.didNotThrow(spy.methodLabel)
         }
 
         if let errorMatcher, !errors.contains(where: errorMatcher.callAsFunction) {
-            throw MockingError.didNotMatchThrown(errors)
+            throw MockingError.didNotMatchThrown(errors, method: spy.methodLabel)
         }
 
         return
@@ -183,11 +217,11 @@ extension Assert where Eff == AsyncThrows {
         }
 
         if errors.isEmpty {
-            throw MockingError.didNotThrow
+            throw MockingError.didNotThrow(spy.methodLabel)
         }
 
         if let errorMatcher, !errors.contains(where: errorMatcher.callAsFunction) {
-            throw MockingError.didNotMatchThrown(errors)
+            throw MockingError.didNotMatchThrown(errors, method: spy.methodLabel)
         }
     }
 

--- a/Sources/SwiftMocking/MockingError.swift
+++ b/Sources/SwiftMocking/MockingError.swift
@@ -27,10 +27,31 @@ public struct MockingError: Error, Equatable, Sendable {
     /// Indicates that a method was expected to throw an error, but it did not.
     public static let didNotThrow = MockingError(message: "Did not find any invocation that throws")
 
+    /// Indicates that a method was expected to throw an error, but it did not.
+    /// - Parameter method: The label of the method that was verified.
+    public static func didNotThrow(_ method: String?) -> MockingError {
+        MockingError(
+            message: describe("Did not find any invocation that throws", method: method)
+        )
+    }
+
     /// Indicates that a method threw an error, but it did not match the expected error.
     /// - Parameter thrown: An array of errors that were actually thrown.
     public static func didNotMatchThrown(_ thrown: [any Error]) -> MockingError {
         return MockingError(message: "Did not match any thrown error. Thrown: \(thrown)")
+    }
+
+    /// Indicates that a method threw an error, but it did not match the expected error.
+    /// - Parameters:
+    ///   - thrown: The errors that were actually thrown.
+    ///   - method: The label of the method that was verified.
+    public static func didNotMatchThrown(_ thrown: [any Error], method: String?) -> MockingError {
+        // `String(reflecting:)` keeps the module qualification (`MyTests.AnotherError()`),
+        // which distinguishes same-named error types declared in different modules.
+        let list = thrown.map { String(reflecting: $0) }.joined(separator: ", ")
+        return MockingError(
+            message: describe("Did not match any thrown error. Thrown: [\(list)]", method: method)
+        )
     }
 
     /// Indicates that the actual call count of a method did not match the expected call count.
@@ -39,8 +60,66 @@ public struct MockingError: Error, Equatable, Sendable {
         MockingError(message: "Unfulfilled call count. Actual: \(actual)")
     }
 
+    /// Indicates that the actual call count of a method did not match the expected call count.
+    ///
+    /// Includes the method label, what was expected, and the invocations that *were*
+    /// recorded, so the failure can be diagnosed without re-reading the test.
+    /// - Parameters:
+    ///   - actual: The actual number of times the method was called.
+    ///   - expected: A description of the expected count, e.g. `equal to 2`.
+    ///   - method: The label of the method that was verified.
+    ///   - recorded: Descriptions of the invocations recorded on the spy.
+    public static func unfulfilledCallCount(
+        _ actual: Int,
+        expected: String?,
+        method: String?,
+        recorded: [String]
+    ) -> MockingError {
+        var message = describe("Unfulfilled call count", method: method)
+        if let expected {
+            message += " Expected \(expected), but was called \(actual) time(s)."
+        } else {
+            message += " Actual: \(actual)."
+        }
+        message += recordedSuffix(recorded)
+        return MockingError(message: message)
+    }
+
     /// Indicates that no matching invocations were found for captured() inspection.
     public static let noMatchingInvocations = MockingError(message: "No matching invocations found for captured() inspection")
+
+    /// Indicates that no matching invocations were found for captured() inspection.
+    /// - Parameters:
+    ///   - method: The label of the method that was inspected.
+    ///   - recorded: Descriptions of the invocations recorded on the spy.
+    public static func noMatchingInvocations(method: String?, recorded: [String]) -> MockingError {
+        let message = describe(
+            "No matching invocations found for captured() inspection",
+            method: method
+        ) + recordedSuffix(recorded)
+        return MockingError(message: message)
+    }
+
+    /// Terminates a message with the method label, when one is known.
+    ///
+    /// Always ends the clause with a period so callers can append further sentences
+    /// without producing run-on text, whether or not a label was available.
+    private static func describe(_ message: String, method: String?) -> String {
+        guard let method else { return "\(message)." }
+        return "\(message) for \"\(method)\"."
+    }
+
+    /// Renders the recorded invocations, or an explicit note that there were none.
+    ///
+    /// Distinguishing "never called" from "called with other arguments" is usually the
+    /// fastest route to the cause of a verification failure.
+    private static func recordedSuffix(_ recorded: [String]) -> String {
+        guard !recorded.isEmpty else {
+            return "\nNo invocations were recorded."
+        }
+        let list = recorded.map { "  - \($0)" }.joined(separator: "\n")
+        return "\nRecorded invocations:\n\(list)"
+    }
 }
 
 /// An error thrown when `until` fails to observe a matching interaction before timing out.

--- a/Tests/SwiftMockingTests/AssertTests.swift
+++ b/Tests/SwiftMockingTests/AssertTests.swift
@@ -29,7 +29,9 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .unfulfilledCallCount(0))
+            XCTAssertTrue(error.message.contains("Unfulfilled call count"), error.message)
+            XCTAssertTrue(error.message.contains("at least 1 call"), error.message)
+            XCTAssertTrue(error.message.contains("No invocations were recorded"), error.message)
         }
     }
 
@@ -40,7 +42,9 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .unfulfilledCallCount(0))
+            XCTAssertTrue(error.message.contains("Unfulfilled call count"), error.message)
+            // The recorded-but-unmatched invocation is what explains the failure.
+            XCTAssertTrue(error.message.contains("(other)"), error.message)
         }
     }
 
@@ -62,7 +66,10 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .didNotThrow)
+            XCTAssertTrue(
+                error.message.contains("Did not find any invocation that throws"),
+                error.message
+            )
         }
     }
 
@@ -85,7 +92,8 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .didNotMatchThrown([AnotherError()]))
+            XCTAssertTrue(error.message.contains("Did not match any thrown error"), error.message)
+            XCTAssertTrue(error.message.contains("AnotherError"), error.message)
         }
     }
 
@@ -205,24 +213,36 @@ final class AssertTests: XCTestCase {
     
     func testCapturedThrowsWhenNoMatchingInvocations() {
         let assert = Assert(spy: spy)
-        
+
         XCTAssertThrowsError(try assert.captures { _ in }) { error in
             guard let mockingError = error as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(mockingError, .noMatchingInvocations)
+            XCTAssertTrue(
+                mockingError.message.contains("No matching invocations found"),
+                mockingError.message
+            )
+            XCTAssertTrue(
+                mockingError.message.contains("No invocations were recorded"),
+                mockingError.message
+            )
         }
     }
-    
+
     func testCapturedThrowsWhenNoMatchingInvocationsWithMatcher() {
         spy("hello")
         let assert = Assert(invocationMatcher: .init(matchers: .equal("world")), spy: spy)
-        
+
         XCTAssertThrowsError(try assert.captures { _ in }) { error in
             guard let mockingError = error as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(mockingError, .noMatchingInvocations)
+            XCTAssertTrue(
+                mockingError.message.contains("No matching invocations found"),
+                mockingError.message
+            )
+            // Surfacing the non-matching invocation is the point of the enriched message.
+            XCTAssertTrue(mockingError.message.contains("(hello)"), mockingError.message)
         }
     }
     

--- a/Tests/SwiftMockingTests/IssueLocationTests.swift
+++ b/Tests/SwiftMockingTests/IssueLocationTests.swift
@@ -142,6 +142,22 @@ final class IssueLocationTests: XCTestCase {
         assertAttributedToThisFile(captured, expectedLine: line)
     }
 
+    /// The enriched message must name the method and show what was actually recorded,
+    /// so a failure is diagnosable without re-reading the test.
+    func testReportedMessageNamesTheMethodAndRecordedInvocations() {
+        let mock = Mock()
+        let spy: Spy<String, None, Void> = mock.fetch
+        when(spy(.any)).thenReturn(())
+        spy("actual")
+
+        let captured = captureIssues {
+            verify(spy(.equal("expected"))).called(1)
+        }
+        let message = captured.first?.message ?? ""
+        XCTAssertTrue(message.contains("fetch"), message)
+        XCTAssertTrue(message.contains("(actual)"), message)
+    }
+
     /// A verification that passes must report nothing at all.
     func testNoIssueReportedOnSuccess() {
         let spy = Spy<String, None, Void>()


### PR DESCRIPTION
> Stacked on #111. Review that first; this PR targets `reporting/source-location`.

## What

Failure messages now carry the method label, what was expected, and what the mock actually recorded.

Before:
```
Unfulfilled call count. Actual: 0
```

After:
```
Unfulfilled call count for "MockPricingService.price". Expected at least 1 call,
but was called 0 time(s).
Recorded invocations:
  - (apple)
  - (banana)
```

## Why

The old message was technically accurate and practically useless: it sent the reader back to the test to recover what was expected, and said nothing about what the mock saw. `Assert` already holds `spy.methodLabel` and `spy.invocations`, so the information was there for free.

The full invocation list is shown rather than only matches: a verification usually fails *because* the recorded arguments differ from the expected ones, and that difference is invisible if non-matching invocations are filtered out. When nothing was recorded the message says so explicitly — "never called" and "called with different arguments" are different bugs with different fixes.

`didNotThrow` and `didNotMatchThrown` gain method-label overloads, and thrown errors render via `String(reflecting:)` so same-named error types from different modules stay distinguishable.

## Deliberate limits

Only the *implicit* call-count default is described. `ArgMatcher` wraps an opaque predicate, so probing a caller-supplied matcher at sample counts risks naming an expectation the user never wrote — an earlier draft did this and could mislabel `.greaterThan(5)`.

## Compatibility

The original factory members are kept, so existing callers keep compiling. `AssertTests` now assert on message *content* rather than exact equality, so wording can evolve without churn.

## Testing

224 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assertion failure messages with method names and recorded invocations.
  * Clarified call-count failures, including expected counts and actual calls.
  * Enhanced capture and throw verification errors with more actionable details.
  * Improved formatting of thrown error types for easier diagnosis.
* **Tests**
  * Expanded coverage for descriptive failure messages and recorded invocation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->