### PR TITLE
Attribute unstubbed mock calls to the @Mockable protocol

### DIFF
--- a/Examples/Tests/ExamplesTests/ErrorReportingTests.swift
+++ b/Examples/Tests/ExamplesTests/ErrorReportingTests.swift
@@ -1,0 +1,290 @@
+import Testing
+import IssueReporting
+import SwiftMocking
+import Foundation
+@testable import Examples
+
+/// Captures issues reported inside an operation, along with where they were attributed.
+///
+/// SwiftMocking reports failures through `IssueReporting`, which normally routes them to
+/// the surrounding test framework. Installing this reporter instead lets a *passing* test
+/// assert on what a failure would have looked like — both its message and, crucially, the
+/// source location it was pinned to.
+private final class IssueProbe: IssueReporter, @unchecked Sendable {
+    struct Captured {
+        let message: String
+        /// `#fileID` form, e.g. `ExamplesTests/ErrorReportingTests.swift`.
+        let fileID: String
+        let line: UInt
+    }
+
+    private let lock = NSLock()
+    private var _captured: [Captured] = []
+
+    var captured: [Captured] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _captured
+    }
+
+    func reportIssue(
+        _ message: @autoclosure () -> String?,
+        severity: IssueSeverity,
+        fileID: StaticString,
+        filePath: StaticString,
+        line: UInt,
+        column: UInt
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        _captured.append(
+            Captured(message: message() ?? "", fileID: "\(fileID)", line: line)
+        )
+    }
+}
+
+/// Runs `body` with issue reporting redirected to a probe, and returns what was captured.
+private func captureIssues(_ body: () -> Void) -> [IssueProbe.Captured] {
+    let probe = IssueProbe()
+    withIssueReporters([probe], operation: body)
+    return probe.captured
+}
+
+/// Async counterpart of ``captureIssues(_:)``.
+private func captureIssues(
+    _ body: () async -> Void
+) async -> [IssueProbe.Captured] {
+    let probe = IssueProbe()
+    await withIssueReporters([probe], operation: body)
+    return probe.captured
+}
+
+/// Demonstrates what SwiftMocking tells you when a test goes wrong.
+///
+/// A mocking library is only as good as its failure messages: the value of a mock shows up
+/// on the day a test breaks, not the day it passes. These tests pin the two properties that
+/// determine whether a failure is actionable — *where* it points, and *what it says*.
+@Suite
+struct ErrorReportingTests {
+
+    // MARK: - Where failures point
+
+    /// A failed verification is attributed to the line that asked for it.
+    ///
+    /// This is the property most likely to regress silently. `IssueReporting` derives the
+    /// displayed file, and swift-testing's whole `SourceLocation`, from `fileID` — not from
+    /// `filePath`. A library that forwards only `filePath` still *appears* to work: the line
+    /// number is right, so the failure looks plausible, while the file it names belongs to
+    /// the mocking library. Clicking it lands you in someone else's source.
+    @Test
+    func failedVerificationPointsAtTheAssertion() {
+        let mock = MockPricingService()
+
+        let expectedLine = UInt(#line + 2)
+        let issues = captureIssues {
+            verify(mock.price(.any)).called(1)
+        }
+
+        let issue = try! #require(issues.first)
+        #expect(issue.fileID == "\(#fileID)")
+        #expect(issue.line == expectedLine)
+    }
+
+    /// Every verification entry point carries its own location, not just `called`.
+    ///
+    /// These share no code path beyond the reporting call, so each one has to thread the
+    /// location independently — which is exactly the kind of repetition that rots.
+    @Test
+    func allVerificationEntryPointsCarryTheirLocation() throws {
+        let mock = MockPricingService()
+        when(mock.price(.any)).thenReturn(1)
+        _ = try mock.price("apple")
+
+        let neverLine = UInt(#line + 2)
+        let neverIssues = captureIssues {
+            verifyNever(mock.price(.any))
+        }
+        #expect(neverIssues.first?.line == neverLine)
+        #expect(neverIssues.first?.fileID == "\(#fileID)")
+
+        let orderLine = UInt(#line + 2)
+        let orderIssues = captureIssues {
+            verifyInOrder([mock.price("never-called")])
+        }
+        #expect(orderIssues.first?.line == orderLine)
+        #expect(orderIssues.first?.fileID == "\(#fileID)")
+
+        let zeroLine = UInt(#line + 2)
+        let zeroIssues = captureIssues {
+            verifyZeroInteractions(mock)
+        }
+        #expect(zeroIssues.first?.line == zeroLine)
+        #expect(zeroIssues.first?.fileID == "\(#fileID)")
+    }
+
+    /// Two verifications of the same method report their own distinct lines.
+    ///
+    /// Worth pinning because it rules out a tempting shortcut: caching a location on the
+    /// spy. Spies are created once per requirement and reused for every call, so a stored
+    /// location would report whichever call site happened to create the spy — here, the
+    /// first verification — for both failures.
+    @Test
+    func repeatedVerificationsReportDistinctLines() {
+        let mock = MockPricingService()
+
+        let firstLine = UInt(#line + 2)
+        let first = captureIssues {
+            verify(mock.price(.any)).called(1)
+        }
+
+        let secondLine = UInt(#line + 2)
+        let second = captureIssues {
+            verify(mock.price(.any)).called(2)
+        }
+
+        #expect(first.first?.line == firstLine)
+        #expect(second.first?.line == secondLine)
+        #expect(firstLine != secondLine)
+    }
+
+    /// A passing verification reports nothing at all.
+    @Test
+    func passingVerificationReportsNothing() throws {
+        let mock = MockPricingService()
+        when(mock.price(.any)).thenReturn(13)
+        _ = try mock.price("apple")
+
+        let issues = captureIssues {
+            verify(mock.price(.any)).called(1)
+        }
+        #expect(issues.isEmpty)
+    }
+
+    // MARK: - What failures say
+
+    /// A call-count failure names the method, what was expected, and what was recorded.
+    ///
+    /// "Unfulfilled call count. Actual: 0" is technically accurate and practically useless:
+    /// it sends you back to the test to recover what was expected, and says nothing about
+    /// what the mock actually saw.
+    @Test
+    func callCountFailureExplainsItself() throws {
+        let mock = MockPricingService()
+        when(mock.price(.any)).thenReturn(1)
+        _ = try mock.price("apple")
+        _ = try mock.price("banana")
+
+        let issues = captureIssues {
+            verify(mock.price("cherry")).called(1)
+        }
+
+        let message = try #require(issues.first?.message)
+        // Which requirement failed.
+        #expect(message.contains("price"))
+        // What the mock actually saw — the usual cause of the failure.
+        #expect(message.contains("(apple)"))
+        #expect(message.contains("(banana)"))
+    }
+
+    /// When nothing was recorded, the message says so rather than showing an empty list.
+    ///
+    /// "Never called" and "called with different arguments" are different bugs with
+    /// different fixes, and the message should not make you guess which one you have.
+    @Test
+    func neverCalledIsDistinguishedFromCalledWithOtherArguments() throws {
+        let mock = MockPricingService()
+
+        let untouched = captureIssues {
+            verify(mock.price(.any)).called(1)
+        }
+        #expect(try #require(untouched.first?.message).contains("No invocations were recorded"))
+
+        when(mock.price(.any)).thenReturn(1)
+        _ = try mock.price("apple")
+
+        let mismatched = captureIssues {
+            verify(mock.price("cherry")).called(1)
+        }
+        let message = try #require(mismatched.first?.message)
+        #expect(message.contains("Recorded invocations"))
+        #expect(message.contains("(apple)"))
+    }
+
+    /// The implicit "at least once" default is spelled out, since it appears nowhere in the
+    /// test source for the reader to check against.
+    @Test
+    func implicitCallCountExpectationIsSpelledOut() throws {
+        let mock = MockPricingService()
+
+        let issues = captureIssues {
+            verify(mock.price(.any)).called()
+        }
+        #expect(try #require(issues.first?.message).contains("at least 1 call"))
+    }
+
+    /// `captured` reports the same detail when no invocation matches.
+    @Test
+    func capturedFailureListsRecordedInvocations() throws {
+        let mock = MockPricingService()
+        when(mock.price(.any)).thenReturn(1)
+        _ = try mock.price("apple")
+
+        let issues = captureIssues {
+            verify(mock.price("cherry")).captured { _ in }
+        }
+
+        let message = try #require(issues.first?.message)
+        #expect(message.contains("price"))
+        #expect(message.contains("(apple)"))
+    }
+
+    // MARK: - Unstubbed requirements
+
+    /// An unstubbed *throwing* requirement surfaces as a thrown `MockingError` naming the
+    /// method and the arguments it was called with.
+    ///
+    /// Nothing is reported separately here: the thrown error already carries the full
+    /// message and the test framework surfaces it at the caller's `try`. Reporting as well
+    /// would duplicate one failure into two.
+    @Test
+    func unstubbedThrowingRequirementThrowsADescriptiveError() async {
+        let mock = MockFeedService()
+        let url = URL(string: "https://example.com")!
+
+        let issues = await captureIssues {
+            do {
+                // `Data` has no registered default, so this reaches the unstubbed path.
+                _ = try await mock.fetch(from: url)
+                Issue.record("Expected the unstubbed requirement to throw")
+            } catch let error as MockingError {
+                #expect(error.message.contains("MockFeedService"))
+                #expect(error.message.contains("fetch"))
+                #expect(error.message.contains("example.com"))
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+        #expect(issues.isEmpty, "The thrown error is the report; it should not be duplicated")
+    }
+
+    /// A stubbed error propagates untouched.
+    ///
+    /// `thenThrow` describes behavior the test asked for, not a mocking failure, so it must
+    /// not be reported as an issue.
+    @Test
+    func stubbedErrorsPropagateWithoutBeingReported() {
+        let mock = MockPricingService()
+        when(mock.price(.any)).thenThrow(ExampleError.boom)
+
+        let issues = captureIssues {
+            #expect(throws: ExampleError.boom) {
+                _ = try mock.price("apple")
+            }
+        }
+        #expect(issues.isEmpty)
+    }
+}
+
+private enum ExampleError: Error, Equatable {
+    case boom
+}

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -252,7 +252,8 @@ extension MockableGenerator {
     /// adapt(super.myMethod, param1)
     /// ```
     private static func adaptCall(effectType: EffectType, requirementName: TokenSyntax, parameters: [ExprSyntax]) -> FunctionCallExprSyntax {
-        let adaptingName = "adapt" + (effectType.rawValue.contains("Throws") ? "Throwing" : "")
+        let isThrowing = effectType.rawValue.contains("Throws")
+        let adaptingName = "adapt" + (isThrowing ? "Throwing" : "")
         return FunctionCallExprSyntax(
             calledExpression: DeclReferenceExprSyntax(
                 baseName: .identifier(adaptingName)
@@ -278,6 +279,29 @@ extension MockableGenerator {
                     for parameter in parameters {
                         LabeledExprSyntax(expression: parameter)
                     }
+                }
+
+                // Source location of the requirement being mocked.
+                //
+                // These magic literals are expanded where the macro's output is attached —
+                // the user's `@Mockable` protocol — so they resolve to that protocol's file
+                // and line rather than anywhere inside SwiftMocking. Passing them as
+                // *arguments* keeps the generated method's signature identical to the
+                // protocol requirement; adding them as parameters would break conformance.
+                //
+                // Only the non-throwing adapters take a location. A throwing requirement
+                // surfaces an unstubbed call as a thrown `MockingError` carrying the full
+                // message, which the test framework already reports; passing a location
+                // there would only add a duplicate, message-less issue.
+                for name in isThrowing ? [] : ["fileID", "filePath", "line", "column"] {
+                    LabeledExprSyntax(
+                        label: .identifier(name),
+                        colon: .colonToken(),
+                        expression: MacroExpansionExprSyntax(
+                            macroName: .identifier(name),
+                            arguments: LabeledExprListSyntax()
+                        )
+                    )
                 }
             },
             rightParen: .rightParenToken()

--- a/Sources/SwiftMocking/Assert.swift
+++ b/Sources/SwiftMocking/Assert.swift
@@ -57,7 +57,38 @@ public class Assert<each Input, Eff: Effect, Output> {
         let countMatcher = matcher ?? .greaterThan(.zero)
         let count = if let invocationMatcher { spy.invocationCount(matching: invocationMatcher) } else { spy.invocations.count }
         if !countMatcher(count) {
-            throw MockingError.unfulfilledCallCount(count)
+            throw MockingError.unfulfilledCallCount(
+                count,
+                expected: Self.describeExpectation(matcher),
+                method: spy.methodLabel,
+                recorded: recordedDescriptions()
+            )
+        }
+    }
+
+    /// Describes the expected call count for the failure message.
+    ///
+    /// ``ArgMatcher`` wraps an opaque predicate, so a caller-supplied matcher cannot be
+    /// rendered — probing it at sample counts would risk naming an expectation the user
+    /// never expressed. Only the implicit default is described, since that is the one
+    /// expectation absent from the test source.
+    private static func describeExpectation(_ matcher: ArgMatcher<Int>?) -> String? {
+        matcher == nil ? "at least 1 call" : nil
+    }
+
+    /// Renders every invocation recorded on the spy, marking which ones matched.
+    ///
+    /// The full list is shown rather than only the matches: a verification usually fails
+    /// *because* the recorded arguments differ from the expected ones, and that difference
+    /// is invisible if non-matching invocations are filtered out.
+    func recordedDescriptions() -> [String] {
+        let all = spy.invocations
+        guard let invocationMatcher else {
+            return all.map { $0.debugDescription }
+        }
+        return all.map { invocation in
+            let matched = invocationMatcher.isMatchedBy(invocation)
+            return "\(invocation.debugDescription)\(matched ? " (matched)" : "")"
         }
     }
 
@@ -84,7 +115,10 @@ public class Assert<each Input, Eff: Effect, Output> {
     func captures(_ inspector: @escaping (repeat each Input) throws -> Void) throws {
         let matchingInvocations = getMatchingInvocations()
         guard !matchingInvocations.isEmpty else {
-            throw MockingError.noMatchingInvocations
+            throw MockingError.noMatchingInvocations(
+                method: spy.methodLabel,
+                recorded: recordedDescriptions()
+            )
         }
         
         for invocation in matchingInvocations {
@@ -143,11 +177,11 @@ extension Assert where Eff == Throws {
         }
 
         if errors.isEmpty {
-            throw MockingError.didNotThrow
+            throw MockingError.didNotThrow(spy.methodLabel)
         }
 
         if let errorMatcher, !errors.contains(where: errorMatcher.callAsFunction) {
-            throw MockingError.didNotMatchThrown(errors)
+            throw MockingError.didNotMatchThrown(errors, method: spy.methodLabel)
         }
 
         return
@@ -183,11 +217,11 @@ extension Assert where Eff == AsyncThrows {
         }
 
         if errors.isEmpty {
-            throw MockingError.didNotThrow
+            throw MockingError.didNotThrow(spy.methodLabel)
         }
 
         if let errorMatcher, !errors.contains(where: errorMatcher.callAsFunction) {
-            throw MockingError.didNotMatchThrown(errors)
+            throw MockingError.didNotMatchThrown(errors, method: spy.methodLabel)
         }
     }
 

--- a/Sources/SwiftMocking/Mock+Adapters.swift
+++ b/Sources/SwiftMocking/Mock+Adapters.swift
@@ -13,151 +13,219 @@ import Foundation
 /// calls through the spy infrastructure. They handle the different effect types
 /// (async, throws, async throws). The mock's default provider registry is captured by
 /// each spy once, at creation time (in `Mock`'s subscript), not re-applied per call.
+///
+/// ## Source location
+///
+/// Each adapter takes a trailing `fileID`/`filePath`/`line`/`column` group describing
+/// where the mocked requirement is declared. The generated conformance passes `#fileID`,
+/// `#filePath`, `#line`, and `#column` explicitly, and because those literals are expanded
+/// inside the macro's output — which is attached to the user's `@Mockable` protocol — they
+/// resolve to that protocol's own source file and line.
+///
+/// This is deliberately *not* the call site of the mocked method. A conformance witness
+/// must match the protocol requirement's signature exactly, so extra defaulted parameters
+/// on the generated method would break conformance:
+///
+/// ```swift
+/// protocol P { func f(_ x: Int) -> Int }
+/// // error: type 'Impl' does not conform to protocol 'P'
+/// struct Impl: P { func f(_ x: Int, fileID: StaticString = #fileID) -> Int { x } }
+/// ```
+///
+/// Pointing at the protocol declaration is therefore the closest attribution available for
+/// requirements invoked from production code, and it is strictly better than the previous
+/// behavior of pointing inside SwiftMocking itself.
 public extension Mock {
     /// Adapts a synchronous spy call for static method mocking.
-    ///
-    /// This adapter is used by generated static mock methods to invoke the
-    /// underlying spy while ensuring proper configuration inheritance.
     ///
     /// - Parameters:
     ///   - spy: The spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
+    ///   - fileID: Where the mocked requirement is declared.
+    ///   - filePath: Where the mocked requirement is declared.
+    ///   - line: Where the mocked requirement is declared.
+    ///   - column: Where the mocked requirement is declared.
     /// - Returns: The result of the spy invocation.
     @inlinable
     @inline(__always)
-    static func adapt<each I, O>(_ spy: Spy<repeat each I, None, O>, _ input: repeat each I) -> O {
+    static func adapt<each I, O>(
+        _ spy: Spy<repeat each I, None, O>,
+        _ input: repeat each I,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) -> O {
         do {
             return try spy.process(repeat each input)
-        } catch let error as MockingError {
-            fatalError("MockingError: \(error.message)")
         } catch {
-            fatalError("\(error.localizedDescription)")
+            reportUnrecoverable(
+                error,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
         }
     }
 
     /// Adapts a synchronous spy call for instance method mocking.
     ///
-    /// This adapter is used by generated instance mock methods to invoke the
-    /// underlying spy while ensuring proper configuration inheritance.
-    ///
     /// - Parameters:
     ///   - spy: The spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
+    ///   - fileID: Where the mocked requirement is declared.
+    ///   - filePath: Where the mocked requirement is declared.
+    ///   - line: Where the mocked requirement is declared.
+    ///   - column: Where the mocked requirement is declared.
     /// - Returns: The result of the spy invocation.
     @inlinable
     @inline(__always)
-    func adapt<each I, O>(_ spy: Spy<repeat each I, None, O>, _ input: repeat each I) -> O {
+    func adapt<each I, O>(
+        _ spy: Spy<repeat each I, None, O>,
+        _ input: repeat each I,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) -> O {
         do {
             return try spy.process(repeat each input)
-        } catch let error as MockingError {
-            fatalError("MockingError: \(error.message)")
         } catch {
-            fatalError("\(error.localizedDescription)")
+            reportUnrecoverable(
+                error,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
         }
     }
 
     /// Adapts an asynchronous spy call for static method mocking.
     ///
-    /// This adapter handles async method calls in generated static mock methods,
-    /// ensuring proper async context and configuration inheritance.
-    ///
     /// - Parameters:
     ///   - spy: The async spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
+    ///   - fileID: Where the mocked requirement is declared.
+    ///   - filePath: Where the mocked requirement is declared.
+    ///   - line: Where the mocked requirement is declared.
+    ///   - column: Where the mocked requirement is declared.
     /// - Returns: The result of the async spy invocation.
     @inlinable
     @inline(__always)
-    static func adapt<each I, O>(_ spy: Spy<repeat each I, Async, O>, _ input: repeat each I) async -> O {
+    static func adapt<each I, O>(
+        _ spy: Spy<repeat each I, Async, O>,
+        _ input: repeat each I,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) async -> O {
         do {
             return try await spy.process(repeat each input)
-        } catch let error as MockingError {
-            fatalError("MockingError: \(error.message)")
         } catch {
-            fatalError("\(error.localizedDescription)")
+            reportUnrecoverable(
+                error,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
         }
     }
 
     /// Adapts an asynchronous spy call for instance method mocking.
     ///
-    /// This adapter handles async method calls in generated instance mock methods,
-    /// ensuring proper async context and configuration inheritance.
-    ///
     /// - Parameters:
     ///   - spy: The async spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
+    ///   - fileID: Where the mocked requirement is declared.
+    ///   - filePath: Where the mocked requirement is declared.
+    ///   - line: Where the mocked requirement is declared.
+    ///   - column: Where the mocked requirement is declared.
     /// - Returns: The result of the async spy invocation.
     @inlinable
     @inline(__always)
-    func adapt<each I, O>(_ spy: Spy<repeat each I, Async, O>, _ input: repeat each I) async -> O {
+    func adapt<each I, O>(
+        _ spy: Spy<repeat each I, Async, O>,
+        _ input: repeat each I,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) async -> O {
         do {
             return try await spy.process(repeat each input)
-        } catch let error as MockingError {
-            fatalError("MockingError: \(error.message)")
         } catch {
-            fatalError("\(error.localizedDescription)")
+            reportUnrecoverable(
+                error,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
         }
     }
 
     /// Adapts a throwing spy call for static method mocking.
     ///
-    /// This adapter handles methods that can throw errors in generated static
-    /// mock methods, ensuring proper error propagation and configuration inheritance.
+    /// Unlike the non-throwing adapters, an unstubbed requirement here surfaces as a thrown
+    /// ``MockingError`` carrying the full message, so no issue is reported separately: the
+    /// test framework already surfaces the error where the caller's `try` is caught. Adding
+    /// a second report would duplicate the failure without adding information.
     ///
     /// - Parameters:
     ///   - spy: The throwing spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
     /// - Returns: The result of the spy invocation.
     /// - Throws: Any error thrown by the spy or stubbed behavior.
-    static func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, Throws, O>, _ input: repeat each I) throws -> O {
-        let result = try spy(repeat each input)
-        return result
+    static func adaptThrowing<each I, O>(
+        _ spy: Spy<repeat each I, Throws, O>,
+        _ input: repeat each I
+    ) throws -> O {
+        return try spy(repeat each input)
     }
 
     /// Adapts a throwing spy call for instance method mocking.
     ///
-    /// This adapter handles methods that can throw errors in generated instance
-    /// mock methods, ensuring proper error propagation and configuration inheritance.
-    ///
     /// - Parameters:
     ///   - spy: The throwing spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
     /// - Returns: The result of the spy invocation.
     /// - Throws: Any error thrown by the spy or stubbed behavior.
-    func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, Throws, O>, _ input: repeat each I) throws -> O {
-        let result = try spy(repeat each input)
-        return result
+    func adaptThrowing<each I, O>(
+        _ spy: Spy<repeat each I, Throws, O>,
+        _ input: repeat each I
+    ) throws -> O {
+        return try spy(repeat each input)
     }
 
     /// Adapts an async throwing spy call for static method mocking.
     ///
-    /// This adapter handles methods that are both async and throwing in generated
-    /// static mock methods, ensuring proper async context, error propagation,
-    /// and configuration inheritance.
-    ///
     /// - Parameters:
     ///   - spy: The async throwing spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
     /// - Returns: The result of the async spy invocation.
     /// - Throws: Any error thrown by the spy or stubbed behavior.
-    static func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, AsyncThrows, O>, _ input: repeat each I) async throws -> O {
-        let result = try await spy(repeat each input)
-        return result
+    static func adaptThrowing<each I, O>(
+        _ spy: Spy<repeat each I, AsyncThrows, O>,
+        _ input: repeat each I
+    ) async throws -> O {
+        return try await spy(repeat each input)
     }
 
     /// Adapts an async throwing spy call for instance method mocking.
     ///
-    /// This adapter handles methods that are both async and throwing in generated
-    /// instance mock methods, ensuring proper async context, error propagation,
-    /// and configuration inheritance.
-    ///
     /// - Parameters:
     ///   - spy: The async throwing spy instance to invoke.
     ///   - input: The input arguments to pass to the spy.
     /// - Returns: The result of the async spy invocation.
     /// - Throws: Any error thrown by the spy or stubbed behavior.
-    func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, AsyncThrows, O>, _ input: repeat each I) async throws -> O {
-        let result = try await spy(repeat each input)
-        return result
+    func adaptThrowing<each I, O>(
+        _ spy: Spy<repeat each I, AsyncThrows, O>,
+        _ input: repeat each I
+    ) async throws -> O {
+        return try await spy(repeat each input)
     }
-
 }

--- a/Sources/SwiftMocking/MockingError.swift
+++ b/Sources/SwiftMocking/MockingError.swift
@@ -27,10 +27,31 @@ public struct MockingError: Error, Equatable, Sendable {
     /// Indicates that a method was expected to throw an error, but it did not.
     public static let didNotThrow = MockingError(message: "Did not find any invocation that throws")
 
+    /// Indicates that a method was expected to throw an error, but it did not.
+    /// - Parameter method: The label of the method that was verified.
+    public static func didNotThrow(_ method: String?) -> MockingError {
+        MockingError(
+            message: describe("Did not find any invocation that throws", method: method)
+        )
+    }
+
     /// Indicates that a method threw an error, but it did not match the expected error.
     /// - Parameter thrown: An array of errors that were actually thrown.
     public static func didNotMatchThrown(_ thrown: [any Error]) -> MockingError {
         return MockingError(message: "Did not match any thrown error. Thrown: \(thrown)")
+    }
+
+    /// Indicates that a method threw an error, but it did not match the expected error.
+    /// - Parameters:
+    ///   - thrown: The errors that were actually thrown.
+    ///   - method: The label of the method that was verified.
+    public static func didNotMatchThrown(_ thrown: [any Error], method: String?) -> MockingError {
+        // `String(reflecting:)` keeps the module qualification (`MyTests.AnotherError()`),
+        // which distinguishes same-named error types declared in different modules.
+        let list = thrown.map { String(reflecting: $0) }.joined(separator: ", ")
+        return MockingError(
+            message: describe("Did not match any thrown error. Thrown: [\(list)]", method: method)
+        )
     }
 
     /// Indicates that the actual call count of a method did not match the expected call count.
@@ -39,8 +60,66 @@ public struct MockingError: Error, Equatable, Sendable {
         MockingError(message: "Unfulfilled call count. Actual: \(actual)")
     }
 
+    /// Indicates that the actual call count of a method did not match the expected call count.
+    ///
+    /// Includes the method label, what was expected, and the invocations that *were*
+    /// recorded, so the failure can be diagnosed without re-reading the test.
+    /// - Parameters:
+    ///   - actual: The actual number of times the method was called.
+    ///   - expected: A description of the expected count, e.g. `equal to 2`.
+    ///   - method: The label of the method that was verified.
+    ///   - recorded: Descriptions of the invocations recorded on the spy.
+    public static func unfulfilledCallCount(
+        _ actual: Int,
+        expected: String?,
+        method: String?,
+        recorded: [String]
+    ) -> MockingError {
+        var message = describe("Unfulfilled call count", method: method)
+        if let expected {
+            message += " Expected \(expected), but was called \(actual) time(s)."
+        } else {
+            message += " Actual: \(actual)."
+        }
+        message += recordedSuffix(recorded)
+        return MockingError(message: message)
+    }
+
     /// Indicates that no matching invocations were found for captured() inspection.
     public static let noMatchingInvocations = MockingError(message: "No matching invocations found for captured() inspection")
+
+    /// Indicates that no matching invocations were found for captured() inspection.
+    /// - Parameters:
+    ///   - method: The label of the method that was inspected.
+    ///   - recorded: Descriptions of the invocations recorded on the spy.
+    public static func noMatchingInvocations(method: String?, recorded: [String]) -> MockingError {
+        let message = describe(
+            "No matching invocations found for captured() inspection",
+            method: method
+        ) + recordedSuffix(recorded)
+        return MockingError(message: message)
+    }
+
+    /// Terminates a message with the method label, when one is known.
+    ///
+    /// Always ends the clause with a period so callers can append further sentences
+    /// without producing run-on text, whether or not a label was available.
+    private static func describe(_ message: String, method: String?) -> String {
+        guard let method else { return "\(message)." }
+        return "\(message) for \"\(method)\"."
+    }
+
+    /// Renders the recorded invocations, or an explicit note that there were none.
+    ///
+    /// Distinguishing "never called" from "called with other arguments" is usually the
+    /// fastest route to the cause of a verification failure.
+    private static func recordedSuffix(_ recorded: [String]) -> String {
+        guard !recorded.isEmpty else {
+            return "\nNo invocations were recorded."
+        }
+        let list = recorded.map { "  - \($0)" }.joined(separator: "\n")
+        return "\nRecorded invocations:\n\(list)"
+    }
 }
 
 /// An error thrown when `until` fails to observe a matching interaction before timing out.

--- a/Sources/SwiftMocking/SourceLocation.swift
+++ b/Sources/SwiftMocking/SourceLocation.swift
@@ -150,7 +150,7 @@ public struct SourceLocation: Sendable {
 /// attributed to the calling frame rather than to `reportUnrecoverable` itself. Without it,
 /// the runtime's crash message ends in `at SourceLocation.reportUnrecoverable` and Xcode's
 /// stack navigator selects SwiftMocking's frame instead of the mocked requirement's.
-//@_transparent
+@_transparent
 @usableFromInline
 func reportUnrecoverable(
     _ error: any Error,

--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -340,19 +340,33 @@ extension Spy where Effects == Throws {
 // MARK: None throwing
 extension Spy where Effects == None {
     /// Calls the spy's method, expecting it not to throw an error.
+    ///
+    /// When invoked directly (rather than through a generated conformance) the defaulted
+    /// location parameters capture the caller's own file and line, so an unstubbed call
+    /// is attributed to the calling test.
     /// - Parameter input: The arguments for the method call.
     /// - Returns: The output of the method.
     /// - FatalError: If the method throws an error.
     @inlinable
     @inline(__always)
     @discardableResult
-    public func callAsFunction(_ input: repeat each Input) -> Output {
+    public func callAsFunction(
+        _ input: repeat each Input,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) -> Output {
         do {
             return try process(repeat each input)
-        } catch let error as MockingError {
-            fatalError("MockingError: \(error.message)")
         } catch {
-            fatalError("\(error.localizedDescription)")
+            reportUnrecoverable(
+                error,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
         }
     }
 
@@ -384,13 +398,23 @@ extension Spy where Effects == Async {
     @inlinable
     @inline(__always)
     @discardableResult
-    public func callAsFunction(_ input: repeat each Input) async -> Output {
+    public func callAsFunction(
+        _ input: repeat each Input,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) async -> Output {
         do {
             return try await process(repeat each input)
-        } catch let error as MockingError {
-            fatalError("MockingError: \(error.message)")
         } catch {
-            fatalError("\(error.localizedDescription)")
+            reportUnrecoverable(
+                error,
+                fileID: fileID,
+                filePath: filePath,
+                line: line,
+                column: column
+            )
         }
     }
 

--- a/Tests/SwiftMockingMacrosTests/BasicTests.swift
+++ b/Tests/SwiftMockingMacrosTests/BasicTests.swift
@@ -26,7 +26,7 @@ final class BasicTests: MacroTestCase {
                 }
 
                 func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
+                    return adapt(super.price, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
+++ b/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
@@ -26,7 +26,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
+                    return adapt(super.price, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -55,7 +55,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func print(_ values: String...) {
-                    return adapt(super.print, values)
+                    return adapt(super.print, values, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -113,7 +113,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func price(_ item: String) async -> Int {
-                    return await adapt(super.price, item)
+                    return await adapt(super.price, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -210,7 +210,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func doSomething() -> String {
-                    return adapt(super.doSomething, ())
+                    return adapt(super.doSomething, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -239,7 +239,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func doSomething(with value: Int) {
-                    return adapt(super.doSomething, value)
+                    return adapt(super.doSomething, value, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -268,7 +268,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func doSomething() {
-                    return adapt(super.doSomething, ())
+                    return adapt(super.doSomething, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -298,7 +298,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 static func log(_ message: String) {
-                    return adapt(super.log, message)
+                    return adapt(super.log, message, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -328,7 +328,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func logEvent<E: Identifiable>(_ event: E) -> Bool {
-                    return adapt(super.logEvent, event)
+                    return adapt(super.logEvent, event, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -357,7 +357,7 @@ final class FunctionSignatureTests: MacroTestCase {
                 }
 
                 func execute(completion: @escaping (String) -> Void) {
-                    return adapt(super.execute, completion)
+                    return adapt(super.execute, completion, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -26,7 +26,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 }
 
                 func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
+                    return adapt(super.price, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -54,7 +54,7 @@ final class GeneratorPipelineTests: XCTestCase {
 
                 var value: Int {
                     get {
-                        adapt(super.value, ())
+                        adapt(super.value, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -82,7 +82,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 }
 
                 func doSomething() {
-                    return adapt(super.doSomething, ())
+                    return adapt(super.doSomething, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -177,7 +177,7 @@ final class GeneratorPipelineTests: XCTestCase {
                 }
 
                 func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
+                    return adapt(super.price, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             """

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -26,7 +26,7 @@ final class MacroOptionsTests: MacroTestCase {
                 }
 
                 func doSomething() {
-                    return adapt(super.doSomething, ())
+                    return adapt(super.doSomething, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -55,7 +55,7 @@ final class MacroOptionsTests: MacroTestCase {
                 }
 
                 func doSomething() {
-                    return adapt(super.doSomething, ())
+                    return adapt(super.doSomething, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MockableMacroTests.swift
@@ -30,7 +30,7 @@ final class MockableMacroTests: MacroTestCase {
                 }
 
                 func price(_ item: String) -> Int {
-                    return adapt(super.price, item)
+                    return adapt(super.price, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -27,7 +27,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                 }
 
                 func doSomething() {
-                    return adapt(super.doSomething, ())
+                    return adapt(super.doSomething, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif
@@ -57,7 +57,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 var value: Int {
                     get {
-                        adapt(super.value, ())
+                        adapt(super.value, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -95,10 +95,10 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 var value: Int {
                     set {
-                        return adapt(super.setValue, (), newValue)
+                        return adapt(super.setValue, (), newValue, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                     get {
-                        adapt(super.value, ())
+                        adapt(super.value, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -139,10 +139,10 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 var cachePolicy: String {
                     set {
-                        return adapt(super.setCachePolicy, (), newValue)
+                        return adapt(super.setCachePolicy, (), newValue, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                     get {
-                        adapt(super.cachePolicy, ())
+                        adapt(super.cachePolicy, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -199,7 +199,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 subscript(index: Int) -> String {
                     get {
-                        return adapt(super.subscriptIndex, index)
+                        return adapt(super.subscriptIndex, index, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -239,10 +239,10 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 subscript(index: Int) -> String {
                     set {
-                        return adapt(super.setSubscriptIndex, index, newValue)
+                        return adapt(super.setSubscriptIndex, index, newValue, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                     get {
-                        return adapt(super.subscriptIndex, index)
+                        return adapt(super.subscriptIndex, index, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -278,7 +278,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 subscript <T: Hashable>(item: T) -> String {
                     get {
-                        return adapt(super.subscriptItem, item)
+                        return adapt(super.subscriptItem, item, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -311,7 +311,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 subscript(row: Int, column: Int) -> String {
                     get {
-                        return adapt(super.subscriptRowColumn, row, column)
+                        return adapt(super.subscriptRowColumn, row, column, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -344,7 +344,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
 
                 subscript(_ position: Int) -> String {
                     get {
-                        return adapt(super.subscriptPosition, position)
+                        return adapt(super.subscriptPosition, position, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                     }
                 }
             }
@@ -378,7 +378,7 @@ final class ProtocolFeaturesTests: MacroTestCase {
                 }
 
                 func item() -> Item {
-                    return adapt(super.item, ())
+                    return adapt(super.item, (), fileID: #fileID, filePath: #filePath, line: #line, column: #column)
                 }
             }
             #endif

--- a/Tests/SwiftMockingTests/AssertTests.swift
+++ b/Tests/SwiftMockingTests/AssertTests.swift
@@ -29,7 +29,9 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .unfulfilledCallCount(0))
+            XCTAssertTrue(error.message.contains("Unfulfilled call count"), error.message)
+            XCTAssertTrue(error.message.contains("at least 1 call"), error.message)
+            XCTAssertTrue(error.message.contains("No invocations were recorded"), error.message)
         }
     }
 
@@ -40,7 +42,9 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .unfulfilledCallCount(0))
+            XCTAssertTrue(error.message.contains("Unfulfilled call count"), error.message)
+            // The recorded-but-unmatched invocation is what explains the failure.
+            XCTAssertTrue(error.message.contains("(other)"), error.message)
         }
     }
 
@@ -62,7 +66,10 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .didNotThrow)
+            XCTAssertTrue(
+                error.message.contains("Did not find any invocation that throws"),
+                error.message
+            )
         }
     }
 
@@ -85,7 +92,8 @@ final class AssertTests: XCTestCase {
             guard let error = $0 as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(error, .didNotMatchThrown([AnotherError()]))
+            XCTAssertTrue(error.message.contains("Did not match any thrown error"), error.message)
+            XCTAssertTrue(error.message.contains("AnotherError"), error.message)
         }
     }
 
@@ -205,24 +213,36 @@ final class AssertTests: XCTestCase {
     
     func testCapturedThrowsWhenNoMatchingInvocations() {
         let assert = Assert(spy: spy)
-        
+
         XCTAssertThrowsError(try assert.captures { _ in }) { error in
             guard let mockingError = error as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(mockingError, .noMatchingInvocations)
+            XCTAssertTrue(
+                mockingError.message.contains("No matching invocations found"),
+                mockingError.message
+            )
+            XCTAssertTrue(
+                mockingError.message.contains("No invocations were recorded"),
+                mockingError.message
+            )
         }
     }
-    
+
     func testCapturedThrowsWhenNoMatchingInvocationsWithMatcher() {
         spy("hello")
         let assert = Assert(invocationMatcher: .init(matchers: .equal("world")), spy: spy)
-        
+
         XCTAssertThrowsError(try assert.captures { _ in }) { error in
             guard let mockingError = error as? MockingError else {
                 return XCTFail("Wrong error type")
             }
-            XCTAssertEqual(mockingError, .noMatchingInvocations)
+            XCTAssertTrue(
+                mockingError.message.contains("No matching invocations found"),
+                mockingError.message
+            )
+            // Surfacing the non-matching invocation is the point of the enriched message.
+            XCTAssertTrue(mockingError.message.contains("(hello)"), mockingError.message)
         }
     }
     

--- a/Tests/SwiftMockingTests/IssueLocationTests.swift
+++ b/Tests/SwiftMockingTests/IssueLocationTests.swift
@@ -142,6 +142,22 @@ final class IssueLocationTests: XCTestCase {
         assertAttributedToThisFile(captured, expectedLine: line)
     }
 
+    /// The enriched message must name the method and show what was actually recorded,
+    /// so a failure is diagnosable without re-reading the test.
+    func testReportedMessageNamesTheMethodAndRecordedInvocations() {
+        let mock = Mock()
+        let spy: Spy<String, None, Void> = mock.fetch
+        when(spy(.any)).thenReturn(())
+        spy("actual")
+
+        let captured = captureIssues {
+            verify(spy(.equal("expected"))).called(1)
+        }
+        let message = captured.first?.message ?? ""
+        XCTAssertTrue(message.contains("fetch"), message)
+        XCTAssertTrue(message.contains("(actual)"), message)
+    }
+
     /// A verification that passes must report nothing at all.
     func testNoIssueReportedOnSuccess() {
         let spy = Spy<String, None, Void>()


### PR DESCRIPTION
> Stacked on #112. Review that first; this PR targets `reporting/messages`.
>
> **This is the most debatable PR in the stack — see "Trade-off" below. It is cleanly droppable if the cost isn't worth it.**

## What

An unstubbed requirement invoked from production code used to report from inside SwiftMocking. Non-throwing calls trapped with `SourceLocation.swift:<line>`; throwing calls surfaced only where the caller's `try` was caught — for a `try` in a test body, the test's *declaration* line.

The generated conformance now passes `#fileID`/`#filePath`/`#line`/`#column` to the non-throwing adapters:

```swift
func fakeData<Fake: Encodable>(_ fakeType: Fake.Type) -> Data {
    return adapt(super.fakeData, fakeType, fileID: #fileID, filePath: #filePath, line: #line, column: #column)
}
```

Those literals expand where the macro's output is attached — the user's `@Mockable` protocol — so they resolve to that protocol's own file and line.

Result: `MockedProtocols.swift:118: Fatal error: Unstubbed method "MockFakeProvider.fakeData."` instead of naming this library.

## Why arguments and not parameters

A witness must match the requirement's signature exactly. Compiler-verified:

```swift
protocol P { func f(_ x: Int) -> Int }
struct Impl: P { func f(_ x: Int, fileID: StaticString = #fileID) -> Int { x } }
// error: type 'Impl' does not conform to protocol 'P'
```

This is why the *call site* is unreachable for conformance methods, and why the protocol declaration is the closest available attribution.

## Two mechanisms, verified by ablation

- **Location arguments** fix the message text. With `@_transparent` alone, it reverts to `SourceLocation.swift:174`.
- **`@_transparent`** on `reportUnrecoverable` marks its frame `[system]`, so Xcode's stack navigator selects the mocked requirement rather than SwiftMocking's frame. Without it the message is right but Xcode may still land on the library frame.

Neither alone is sufficient. `fatalError` also now takes the requirement's location — it defaults `file`/`line` to where it is *written*, which was the remaining source of internal attribution.

## Throwing adapters deliberately do not report

The thrown `MockingError` already carries the full message and the framework surfaces it. A second report duplicated one failure into two, and under swift-testing the extra one renders as a bare "Issue recorded" (see Known issue). The generator is effect-aware so throwing requirements keep clean `adaptThrowing(super.price, item)`.

## Trade-off

**Cost:** every generated conformance method is visibly wider, and the generator carries effect-aware branching.

**Benefit:** attribution moves from SwiftMocking's internals to the user's protocol declaration — better, but still not the failing call site.

Since the message already names the method (`"MockFakeProvider.fakeData."`), there is a reasonable argument that the location adds less than it costs in generated-code noise. Kept as a separate PR precisely so it can be dropped without touching #110–#112.

Note there is no in-process test for this behavior: its only observable path is a `fatalError` that kills the test process.

## Known issue (upstream, not introduced here)

Under swift-testing the reported message renders as a bare "Issue recorded". This is an arity mismatch in xctest-dynamic-overlay — `__recordIssue` takes 6 parameters while the caller `unsafeBitCast`s to a 5-parameter signature — present in both 1.11.0 and 2.1.0. Messages render correctly under XCTest, and the `fatalError` message (which carries the useful text) is unaffected.

## Also included

`Examples/Tests/ExamplesTests/ErrorReportingTests.swift` — 10 tests documenting what a user sees when a test breaks, covering #111 and #112. They capture issues with a custom `IssueReporter` so they pass while asserting on what a failure *would* look like. Verified to fail when either behavior regresses.

## Testing

224 tests in the main package, 36 in Examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)