### PR TITLE
Don't emit `mutating` on generated mock members

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -603,7 +603,7 @@ public extension MockableGenerator {
         )
 
         return FunctionDeclSyntax(
-            modifiers: funcDecl.modifiers.trimmed,
+            modifiers: funcDecl.modifiers.withoutValueTypeModifiers.trimmed,
             name: TokenSyntax.identifier(name),
             genericParameterClause: genericParameterClause,
             signature: FunctionSignatureSyntax(

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -76,7 +76,8 @@ extension MockableGenerator {
             // Trimmed because modifiers copied from the protocol carry the
             // source's leading trivia; that stale newline and indentation would
             // otherwise survive into the generated member and misindent it.
-            modifiers: functionDecl.modifiers.trimmed,
+            // `mutating`/`nonmutating` are dropped because the mock is a class.
+            modifiers: functionDecl.modifiers.withoutValueTypeModifiers.trimmed,
             name: functionDecl.name,
             genericParameterClause: functionDecl.genericParameterClause,
             signature: functionDecl.signature,

--- a/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
+++ b/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
@@ -13,6 +13,23 @@ extension DeclModifierSyntax {
     }
 }
 
+extension DeclModifierListSyntax {
+    /// The modifiers with `mutating` and `nonmutating` removed.
+    ///
+    /// Both are legal on a protocol requirement but not on the member generated
+    /// from it, because mocks are classes: `'mutating' is not valid on instance
+    /// methods in classes`. A class satisfies a `mutating` requirement by
+    /// declaring the method without the modifier, so dropping it is what makes
+    /// the conformance compile — callers are unaffected, including through
+    /// generic and existential references.
+    var withoutValueTypeModifiers: DeclModifierListSyntax {
+        filter { modifier in
+            modifier.name.tokenKind != .keyword(.mutating)
+                && modifier.name.tokenKind != .keyword(.nonmutating)
+        }
+    }
+}
+
 extension VariableDeclSyntax {
     /// A boolean value indicating whether the variable has a getter.
     var hasGetter: Bool {

--- a/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
+++ b/Tests/SwiftMockingMacrosTests/ProtocolFeaturesTests.swift
@@ -385,4 +385,76 @@ final class ProtocolFeaturesTests: MacroTestCase {
             """
         }
     }
+
+    /// `mutating` is valid on a protocol requirement but not on a class member,
+    /// so the generated mock must not carry it — `'mutating' is not valid on
+    /// instance methods in classes`. A class conforms by omitting the modifier.
+    func testMutatingRequirementDropsModifier() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol Repository {
+                mutating func save(_ value: String)
+            }
+            """
+        } expansion: {
+            """
+            protocol Repository {
+                mutating func save(_ value: String)
+            }
+
+            #if DEBUG
+            class MockRepository: Mock, @unchecked Sendable, Repository {
+                func save(_ value: ArgMatcher<String>) -> Interaction<String, None, Void> {
+                    Interaction(value, spy: super.save)
+                }
+
+                func save(_ value: String) {
+                    return adapt(super.save, value)
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    /// `static` must survive the same filtering that removes `mutating`.
+    func testMutatingAndStaticRequirementsKeepStatic() {
+        assertMacro {
+            """
+            @Mockable()
+            protocol Repository {
+                mutating func save(_ value: String)
+                static func reset()
+            }
+            """
+        } expansion: {
+            """
+            protocol Repository {
+                mutating func save(_ value: String)
+                static func reset()
+            }
+
+            #if DEBUG
+            class MockRepository: Mock, @unchecked Sendable, Repository {
+                func save(_ value: ArgMatcher<String>) -> Interaction<String, None, Void> {
+                    Interaction(value, spy: super.save)
+                }
+
+                static func reset() -> Interaction<Void, None, Void> {
+                    Interaction(.any, spy: super.reset)
+                }
+
+                func save(_ value: String) {
+                    return adapt(super.save, value)
+                }
+
+                static func reset() {
+                    return adapt(super.reset, ())
+                }
+            }
+            #endif
+            """
+        }
+    }
 }

--- a/Tests/SwiftMockingTests/MutatingRequirementTests.swift
+++ b/Tests/SwiftMockingTests/MutatingRequirementTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import SwiftMocking
+
+@Mockable
+protocol MutatingRepository {
+    mutating func save(_ value: String)
+    mutating func count() -> Int
+    static func reset()
+}
+
+/// Regression tests for `mutating` requirements.
+///
+/// The generator copied protocol modifiers verbatim onto the generated class,
+/// emitting `mutating func` inside a `class` — which is not valid Swift
+/// (`'mutating' is not valid on instance methods in classes`). Every mock for a
+/// protocol with a `mutating` requirement therefore failed to compile.
+///
+/// A class satisfies a `mutating` requirement by declaring the method without
+/// the modifier, so the fix is to drop it. These tests are primarily a
+/// *compile-time* assertion: the snapshot tests in `SwiftMockingMacrosTests`
+/// compare generated text and cannot catch output that is well-formed but
+/// rejected by the compiler. Exercising the mock here proves it builds and
+/// still routes through its spies.
+final class MutatingRequirementTests: XCTestCase {
+    func testMutatingMethod_StubbedValueIsReturned() {
+        let mock = MockMutatingRepository()
+        var repository: MutatingRepository = mock
+        when(mock.count()).thenReturn(3)
+
+        let result = repository.count()
+
+        XCTAssertEqual(result, 3)
+    }
+
+    func testMutatingMethod_InvocationIsRecordedForVerification() {
+        let mock = MockMutatingRepository()
+        var repository: MutatingRepository = mock
+
+        repository.save("apple")
+
+        verify(mock.save(.equal("apple"))).called(1)
+    }
+
+    /// A `mutating` requirement is reachable through a generic context, where
+    /// the call goes through a `var` binding of the concrete mock type.
+    func testMutatingMethod_CalledThroughGenericContext() {
+        struct System<Repository: MutatingRepository> {
+            var repository: Repository
+            mutating func run() { repository.save("pear") }
+        }
+
+        let mock = MockMutatingRepository()
+        var system = System(repository: mock)
+
+        system.run()
+
+        verify(mock.save(.equal("pear"))).called(1)
+    }
+
+    /// `static` must survive the modifier filtering that removes `mutating`.
+    ///
+    /// The call goes through a metatype binding because a bare
+    /// `MockMutatingRepository.reset()` is ambiguous between the conformance
+    /// member and the interaction member, which differ only by return type.
+    func testStaticRequirementIsUnaffected() {
+        MockMutatingRepository.clear()
+        let repository: MutatingRepository.Type = MockMutatingRepository.self
+
+        repository.reset()
+
+        verify(MockMutatingRepository.reset()).called(1)
+    }
+}


### PR DESCRIPTION
## Problem

`@Mockable` generated mocks that failed to compile for any protocol with a `mutating` requirement:

```swift
@Mockable
protocol Repository {
    mutating func save(_ value: String)
}
```

```
error: 'mutating' is not valid on instance methods in classes
```

`mutating` is valid on a protocol requirement but not on a class member, and generated mocks are classes. Both modifier-copy sites forwarded the protocol's modifiers verbatim:

- `functionRequirement` — the conformance member
- `createStubFunction` — the interaction member

There was no test coverage for `mutating` requirements.

## Fix

A class satisfies a `mutating` requirement by declaring the method without the modifier, so the fix is to drop it. New `DeclModifierListSyntax.withoutValueTypeModifiers` helper, applied at both sites:

```diff
-    mutating func save(_ s: String) { return adapt(super.save, s) }
+    func save(_ s: String) { return adapt(super.save, s) }
```

`nonmutating` is filtered alongside it — equally invalid on a class method. Note the property and subscript paths never leaked it, since those accessors are rebuilt from scratch rather than copied; the filter covers the function path, where it can appear. `static` is unaffected and covered by a test.

## Tests

- **`ProtocolFeaturesTests`** — two snapshot tests: `mutating` alone, and `mutating` + `static` together.
- **`MutatingRequirementTests`** (new) — the test that would have caught this. Snapshot tests compare generated *text* and can't detect output that is well-formed but rejected by the compiler, so this target builds and exercises a real mock: stubbing, verification, a call through a generic `System<Repository: MutatingRepository>`, and the static path.

One note: the static test calls through a `MutatingRepository.Type` binding because a bare `MockMutatingRepository.reset()` is ambiguous between the conformance and interaction members, which differ only by return type. That's the pre-existing zero-arg ambiguity, not a regression.

## Verification

| Suite | Result |
|---|---|
| `swift test` | 229 passed, 0 failures |
| `swift test --filter Swift5CompatTests` | 3 passed |
| `cd Examples/ && swift test` | 19 passed |

No existing snapshots required re-recording, confirming the change touches only `mutating`/`nonmutating`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated mocks for protocols containing `mutating` or `nonmutating` requirements.
  * Removed value-type modifiers from class-based mock methods while preserving valid modifiers such as `static`.
  * Ensured stubbing, return values, and invocation tracking continue to work correctly.

* **Tests**
  * Added coverage for mutating instance requirements and mixed mutating/static protocol requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->