### PR TITLE
Add `@Mockable([.composition])` for class-constrained protocols

### DIFF
--- a/Scripts/generate-interface.sh
+++ b/Scripts/generate-interface.sh
@@ -46,14 +46,37 @@ clean_interface() {
     # Strip compiler bookkeeping and non-public surface, then unqualify the
     # names an agent would actually type. perl (not sed) because BSD sed on
     # macOS has no \b word-boundary support.
-    perl -pe '
-        next if s/^\/\/ swift-(interface-format-version|compiler-version|module-flags).*\n//;
-        next if s/^ *\@objc deinit\n//;
-        next if s/^ *\@usableFromInline\n//;
-        next if /internal /  and $_ = "";
+    #
+    # Dropping an `internal` declaration must take its whole body with it.
+    # Deleting only the opening line orphans the closing brace, which leaves
+    # the file unparseable — `internal struct Return<…> {` used to vanish while
+    # its `}` survived and closed the *previous* declaration. So when an
+    # internal line opens a brace, skip through the matching close; internal
+    # members inside a public type (`internal func get() -> R`) are single
+    # lines and drop on their own.
+    perl -ne '
+        if ($skip_until_close) {
+            $depth += tr/{//;
+            $depth -= tr/}//;
+            $skip_until_close = 0 if $depth <= 0;
+            next;
+        }
+        next if /^\/\/ swift-(interface-format-version|compiler-version|module-flags)/;
+        next if /^ *\@objc deinit$/;
+        next if /^ *\@usableFromInline$/;
+        if (/\binternal\b/) {
+            my $opens = tr/{//;
+            my $closes = tr/}//;
+            if ($opens > $closes) {
+                $skip_until_close = 1;
+                $depth = $opens - $closes;
+            }
+            next;
+        }
         s/\@_hasMissingDesignatedInitializers //g;
         s/\@inlinable //g;
         s/\b(SwiftMocking|Swift|_Concurrency)\.//g;
+        print;
     ' "$src" > "$dst"
 
     echo "  $module → $dst ($(wc -l < "$dst" | tr -d ' ') lines)"

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -32,18 +32,21 @@ public extension MockableGenerator {
     ///     Interaction(value, spy: doSomething)
     /// }
     /// ```
-    static func makeInteractions(protocolDecl: ProtocolDeclSyntax) -> [DeclSyntax] {
+    static func makeInteractions(
+        protocolDecl: ProtocolDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> [DeclSyntax] {
         var members = [DeclSyntax]()
 
         for member in protocolDecl.memberBlock.members {
             if let funcDecl = member.decl.as(FunctionDeclSyntax.self) {
-                let stubFunction = processFunc(funcDecl)
+                let stubFunction = processFunc(funcDecl, spyAccess: spyAccess)
                 members.append(stubFunction)
             } else if let varDecl = member.decl.as(VariableDeclSyntax.self) {
-                let stubFunctions = processVar(varDecl)
+                let stubFunctions = processVar(varDecl, spyAccess: spyAccess)
                 members.append(contentsOf: stubFunctions)
             } else if let subscriptDecl = member.decl.as(SubscriptDeclSyntax.self) {
-                members.append(contentsOf: processSubscript(subscriptDecl))
+                members.append(contentsOf: processSubscript(subscriptDecl, spyAccess: spyAccess))
             }
         }
 
@@ -58,7 +61,10 @@ public extension MockableGenerator {
     ///     Interaction(value, spy: super.doSomething)
     /// }
     /// ```
-    private static func processFunc(_ funcDecl: FunctionDeclSyntax) -> DeclSyntax {
+    private static func processFunc(
+        _ funcDecl: FunctionDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> DeclSyntax {
         let funcName = funcDecl.name.text
         let spyPropertyName = funcDecl.name.text
 
@@ -67,7 +73,8 @@ public extension MockableGenerator {
             spyPropertyName: spyPropertyName,
             funcDecl: funcDecl,
             genericParameterClause: funcDecl.genericParameterClause,
-            genericWhereClause: funcDecl.genericWhereClause
+            genericWhereClause: funcDecl.genericWhereClause,
+            spyAccess: spyAccess
         )
 
         return DeclSyntax(stubFunction)
@@ -80,7 +87,10 @@ public extension MockableGenerator {
     /// func name(_ void: Void = ()) -> Interaction<Void, None, String> { ... }
     /// func setName(newValue: ArgMatcher<String>) -> Interaction<String, None, Void> { ... }
     /// ```
-    private static func processVar(_ varDecl: VariableDeclSyntax) -> [DeclSyntax] {
+    private static func processVar(
+        _ varDecl: VariableDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> [DeclSyntax] {
         var decls = [DeclSyntax]()
         for binding in varDecl.bindings {
             guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
@@ -95,14 +105,16 @@ public extension MockableGenerator {
                 decls.append(DeclSyntax(createSettableGetterInteraction(
                     varName: varName,
                     type: type,
-                    modifiers: varDecl.modifiers
+                    modifiers: varDecl.modifiers,
+                    spyAccess: spyAccess
                 )))
             } else {
                 // Getter
                 let getter = createGetterInteraction(
                     varName: varName,
                     type: type,
-                    modifiers: varDecl.modifiers
+                    modifiers: varDecl.modifiers,
+                    spyAccess: spyAccess
                 )
                 decls.append(DeclSyntax(getter))
             }
@@ -115,11 +127,14 @@ public extension MockableGenerator {
     /// Get-only requirements generate an `Interaction` subscript; settable
     /// requirements generate a `SettableInteraction` subscript exposing reads
     /// (`when`/`verify`) and writes (`assigned:`) through one surface.
-    private static func processSubscript(_ subscriptDecl: SubscriptDeclSyntax) -> [DeclSyntax] {
+    private static func processSubscript(
+        _ subscriptDecl: SubscriptDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> [DeclSyntax] {
         if subscriptDecl.hasSetter {
-            return [DeclSyntax(subscriptSettableInteraction(subscriptDecl))]
+            return [DeclSyntax(subscriptSettableInteraction(subscriptDecl, spyAccess: spyAccess))]
         }
-        return [DeclSyntax(subscriptGetterInteraction(subscriptDecl))]
+        return [DeclSyntax(subscriptGetterInteraction(subscriptDecl, spyAccess: spyAccess))]
     }
 
     /// Creates a getter interaction subscript mirroring the requirement's indices.
@@ -130,7 +145,11 @@ public extension MockableGenerator {
     ///     get { Interaction(index, spy: super.index) }
     /// }
     /// ```
-    private static func subscriptGetterInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
+    private static func subscriptGetterInteraction(
+        _ subscriptDecl: SubscriptDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> SubscriptDeclSyntax {
+        let isStatic = subscriptDecl.modifiers.contains(where: \.isStatic)
         let subscriptDecl = SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
@@ -153,7 +172,9 @@ public extension MockableGenerator {
                         bodyBuilder: {
                             createFunctionBody(
                                 spyPropertyName: subscriptDecl.name,
-                                parameterNames: subscriptDecl.parameterClause.parameters
+                                parameterNames: subscriptDecl.parameterClause.parameters,
+                                spyAccess: spyAccess,
+                                isStatic: isStatic
                             ).statements
                         }
                     )
@@ -182,7 +203,10 @@ public extension MockableGenerator {
     ///
     /// Reads record on the `subscript` spy, writes on the `setSubscript` spy with
     /// the written value as a trailing argument.
-    private static func subscriptSettableInteraction(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
+    private static func subscriptSettableInteraction(
+        _ subscriptDecl: SubscriptDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> SubscriptDeclSyntax {
         SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
@@ -214,7 +238,9 @@ public extension MockableGenerator {
                                     inputTypes: subscriptDecl.parameterClause.parameters
                                         .map { removeAttributes($0.type) },
                                     outputType: subscriptDecl.returnClause.type
-                                )
+                                ),
+                                spyAccess: spyAccess,
+                                isStatic: subscriptDecl.modifiers.contains(where: \.isStatic)
                             ).statements
                         }
                     )
@@ -298,7 +324,9 @@ public extension MockableGenerator {
         setterSpyName: String,
         parameterNames: FunctionParameterListSyntax,
         writeSpyType: TypeSyntax,
-        writeInteractionType: TypeSyntax
+        writeInteractionType: TypeSyntax,
+        spyAccess: SpyAccess = .inherited,
+        isStatic: Bool = false
     ) -> CodeBlockSyntax {
         // Relative to the statement's own column: SwiftSyntax supplies the
         // enclosing context's indentation when the body is placed, so these
@@ -307,7 +335,9 @@ public extension MockableGenerator {
         let indent = { (level: Int) in Trivia.spaces(4 * level) }
         let getterCall = interactionCall(
             spyPropertyName: getterSpyName,
-            parameterNames: parameterNames
+            parameterNames: parameterNames,
+            spyAccess: spyAccess,
+            isStatic: isStatic
         )
         let setterCall = interactionCall(
             spyPropertyName: writeSpyBindingName,
@@ -351,10 +381,7 @@ public extension MockableGenerator {
                     ),
                     initializer: InitializerClauseSyntax(
                         equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space),
-                        value: MemberAccessExprSyntax(
-                            base: SuperExprSyntax(),
-                            name: .identifier(setterSpyName)
-                        )
+                        value: spyAccess.spyReference(.identifier(setterSpyName), isStatic: isStatic)
                     )
                 )
             }
@@ -447,9 +474,19 @@ public extension MockableGenerator {
     ///   their input pack from, so `when(mock.name)` and `verify(mock.name)` resolve.
     /// - It keeps the spy's input pack at `(Void)` — the same pack the conformance's
     ///   `adapt(super.name, ())` records on.
-    private static func createGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
+    private static func createGetterInteraction(
+        varName: String,
+        type: TypeSyntax,
+        modifiers: DeclModifierListSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> FunctionDeclSyntax {
         let interactionReturnType = createInteractionReturnType(inputTypes: [], outputType: type, effectType: .none, genericParameterClause: nil)
-        let body = createFunctionBody(spyPropertyName: varName, parameterNames: [])
+        let body = createFunctionBody(
+            spyPropertyName: varName,
+            parameterNames: [],
+            spyAccess: spyAccess,
+            isStatic: modifiers.contains(where: \.isStatic)
+        )
         return FunctionDeclSyntax(
             modifiers: modifiers.trimmed,
             name: .identifier(varName),
@@ -481,7 +518,12 @@ public extension MockableGenerator {
     /// `adapt(super.value, ())`; the write pack is `(Void, newValue)`, matching
     /// the conformance setter's `adapt(super.setValue, (), newValue)` — writes
     /// record the read pack plus the written value.
-    private static func createSettableGetterInteraction(varName: String, type: TypeSyntax, modifiers: DeclModifierListSyntax) -> FunctionDeclSyntax {
+    private static func createSettableGetterInteraction(
+        varName: String,
+        type: TypeSyntax,
+        modifiers: DeclModifierListSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> FunctionDeclSyntax {
         FunctionDeclSyntax(
             modifiers: modifiers.trimmed,
             name: .identifier(varName),
@@ -507,7 +549,9 @@ public extension MockableGenerator {
                 writeInteractionType: writeInteractionType(
                     inputTypes: [TypeSyntax(stringLiteral: "Void")],
                     outputType: type
-                )
+                ),
+                spyAccess: spyAccess,
+                isStatic: modifiers.contains(where: \.isStatic)
             )
         )
     }
@@ -586,7 +630,8 @@ public extension MockableGenerator {
         spyPropertyName: String,
         funcDecl: FunctionDeclSyntax,
         genericParameterClause: GenericParameterClauseSyntax?,
-        genericWhereClause: GenericWhereClauseSyntax?
+        genericWhereClause: GenericWhereClauseSyntax?,
+        spyAccess: SpyAccess = .inherited
     ) -> FunctionDeclSyntax {
 
         let (inputTypes, _, _) = getFunctionParameters(funcDecl)
@@ -599,7 +644,9 @@ public extension MockableGenerator {
         let returnType = createInteractionReturnType(inputTypes: inputTypes, outputType: outputType, effectType: effectType, genericParameterClause: genericParameterClause)
         let body = createFunctionBody(
             spyPropertyName: spyPropertyName,
-            parameterNames: funcDecl.signature.parameterClause.parameters
+            parameterNames: funcDecl.signature.parameterClause.parameters,
+            spyAccess: spyAccess,
+            isStatic: funcDecl.modifiers.contains(where: \.isStatic)
         )
 
         return FunctionDeclSyntax(
@@ -735,8 +782,18 @@ public extension MockableGenerator {
     ///     Interaction(value, spy: doSomething)
     /// }
     /// ```
-    private static func createFunctionBody(spyPropertyName: String, parameterNames: FunctionParameterListSyntax) -> CodeBlockSyntax {
-        return CodeBlockSyntax(statements: [CodeBlockItemSyntax(item: .expr(ExprSyntax(interactionCall(spyPropertyName: spyPropertyName, parameterNames: parameterNames))))])
+    private static func createFunctionBody(
+        spyPropertyName: String,
+        parameterNames: FunctionParameterListSyntax,
+        spyAccess: SpyAccess = .inherited,
+        isStatic: Bool = false
+    ) -> CodeBlockSyntax {
+        return CodeBlockSyntax(statements: [CodeBlockItemSyntax(item: .expr(ExprSyntax(interactionCall(
+            spyPropertyName: spyPropertyName,
+            parameterNames: parameterNames,
+            spyAccess: spyAccess,
+            isStatic: isStatic
+        ))))])
     }
 
     /// Creates an `Interaction(…, spy: super.<spy>)` call expression.
@@ -752,7 +809,9 @@ public extension MockableGenerator {
         spyPropertyName: String,
         parameterNames: FunctionParameterListSyntax,
         newValueName: String? = nil,
-        spyIsLocalBinding: Bool = false
+        spyIsLocalBinding: Bool = false,
+        spyAccess: SpyAccess = .inherited,
+        isStatic: Bool = false
     ) -> FunctionCallExprSyntax {
         FunctionCallExprSyntax(
             callee: DeclReferenceExprSyntax(baseName: .identifier("Interaction"))
@@ -797,10 +856,7 @@ public extension MockableGenerator {
                 label: "spy",
                 expression: spyIsLocalBinding
                     ? ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(spyPropertyName)))
-                    : ExprSyntax(MemberAccessExprSyntax(
-                        base: SuperExprSyntax(),
-                        name: .identifier(spyPropertyName)
-                    ))
+                    : spyAccess.spyReference(.identifier(spyPropertyName), isStatic: isStatic)
             )
 
         }

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -21,21 +21,24 @@ extension MockableGenerator {
     /// }
     /// ```
     /// This function will generate the `doSomething()` function and the `value` computed property.
-    static func makeConformanceRequirements(for protocolDecl: ProtocolDeclSyntax) -> [DeclSyntax] {
+    static func makeConformanceRequirements(
+        for protocolDecl: ProtocolDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> [DeclSyntax] {
         var declarations = [DeclSyntax]()
         for member in protocolDecl.memberBlock.members {
             if let functionDecl = member.decl.as(FunctionDeclSyntax.self) {
-                declarations.append(DeclSyntax(functionRequirement(functionDecl)))
+                declarations.append(DeclSyntax(functionRequirement(functionDecl, spyAccess: spyAccess)))
             } else if let variableDecl = member.decl.as(VariableDeclSyntax.self) {
-                declarations.append(DeclSyntax(variableRequirement(variableDecl)))
+                declarations.append(DeclSyntax(variableRequirement(variableDecl, spyAccess: spyAccess)))
             } else if let subscriptDecl = member.decl.as(SubscriptDeclSyntax.self) {
-                declarations.append(DeclSyntax(subscriptRequirement(subscriptDecl)))
+                declarations.append(DeclSyntax(subscriptRequirement(subscriptDecl, spyAccess: spyAccess)))
             } else if let initDecl = member.decl.as(InitializerDeclSyntax.self) {
                 declarations.append(DeclSyntax(initializerRequirement(initDecl)))
 
             }
         }
-        
+
         return declarations
     }
 
@@ -70,7 +73,10 @@ extension MockableGenerator {
     /// Generates a function declaration that fulfills a protocol requirement.
     ///
     /// For a function `func doSomething()`, this will generate a function with a body that calls the mock's `adapt` function.
-    static func functionRequirement(_ functionDecl: FunctionDeclSyntax) -> FunctionDeclSyntax {
+    static func functionRequirement(
+        _ functionDecl: FunctionDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> FunctionDeclSyntax {
         return FunctionDeclSyntax(
             attributes: functionDecl.attributes,
             // Trimmed because modifiers copied from the protocol carry the
@@ -81,14 +87,18 @@ extension MockableGenerator {
             name: functionDecl.name,
             genericParameterClause: functionDecl.genericParameterClause,
             signature: functionDecl.signature,
-            body: functionRequirementBody(functionDecl)
+            body: functionRequirementBody(functionDecl, spyAccess: spyAccess)
         )
     }
     
     /// Generates a variable declaration that fulfills a protocol requirement.
     ///
     /// For a variable `var value: Int { get }`, this will generate a computed property with a getter that calls the mock's `adapt` function.
-    static func variableRequirement(_ variableDecl: VariableDeclSyntax) -> VariableDeclSyntax {
+    static func variableRequirement(
+        _ variableDecl: VariableDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> VariableDeclSyntax {
+        let isStatic = variableDecl.modifiers.contains(where: \.isStatic)
         return VariableDeclSyntax(
             attributes: variableDecl.attributes,
             modifiers: variableDecl.modifiers.trimmed,
@@ -116,7 +126,9 @@ extension MockableGenerator {
                                                     expression: adaptCall(
                                                         effectType: .none,
                                                         requirementName: .identifier(variableDecl.name.text.setterSpyName),
-                                                        parameters: [ExprSyntax(TupleExprSyntax(elements: LabeledExprListSyntax())), ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))]
+                                                        parameters: [ExprSyntax(TupleExprSyntax(elements: LabeledExprListSyntax())), ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))],
+                                                        spyAccess: spyAccess,
+                                                        isStatic: isStatic
                                                     )
                                                 )
                                             }
@@ -129,7 +141,9 @@ extension MockableGenerator {
                                             adaptCall(
                                                 effectType: .none,
                                                 requirementName: variableDecl.name,
-                                                parameters: []
+                                                parameters: [],
+                                                spyAccess: spyAccess,
+                                                isStatic: isStatic
                                             )
                                         }
                                     )
@@ -148,8 +162,12 @@ extension MockableGenerator {
     /// For a subscript `subscript(index: Int) -> String { get }`, this will generate a subscript with a getter that calls the mock's `adapt` function.
     /// For a settable requirement, it also generates a setter that records the write —
     /// indices followed by `newValue` — on the `set` + capitalized-parameters spy.
-    static func subscriptRequirement(_ subscriptDecl: SubscriptDeclSyntax) -> SubscriptDeclSyntax {
+    static func subscriptRequirement(
+        _ subscriptDecl: SubscriptDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> SubscriptDeclSyntax {
         let parameterNames = subscriptDecl.parameterClause.parameters.map({ ExprSyntax(DeclReferenceExprSyntax(baseName: $0.secondName ?? $0.firstName)) })
+        let isStatic = subscriptDecl.modifiers.contains(where: \.isStatic)
         return SubscriptDeclSyntax(
             attributes: subscriptDecl.attributes,
             modifiers: subscriptDecl.modifiers,
@@ -169,7 +187,9 @@ extension MockableGenerator {
                                         expression: adaptCall(
                                             effectType: .none,
                                             requirementName: .identifier(subscriptDecl.name.setterSpyName),
-                                            parameters: parameterNames + [ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))]
+                                            parameters: parameterNames + [ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("newValue")))],
+                                            spyAccess: spyAccess,
+                                            isStatic: isStatic
                                         )
                                     )
                                 }
@@ -183,7 +203,9 @@ extension MockableGenerator {
                                     expression: adaptCall(
                                         effectType: .none,
                                         requirementName: .identifier(subscriptDecl.name),
-                                        parameters: parameterNames
+                                        parameters: parameterNames,
+                                        spyAccess: spyAccess,
+                                        isStatic: isStatic
                                     )
                                 )
                             }
@@ -201,30 +223,38 @@ extension MockableGenerator {
     /// ```swift
     /// { try adaptThrowing(super.doSomething) }
     /// ```
-    static func functionRequirementBody(_ funcDecl: FunctionDeclSyntax) -> CodeBlockSyntax {
+    static func functionRequirementBody(
+        _ funcDecl: FunctionDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> CodeBlockSyntax {
         let effectType = getFunctionEffectType(funcDecl)
         return CodeBlockSyntax {
             switch effectType {
             case .none:
-                ReturnStmtSyntax(expression: baseFunctionRequirementBody(funcDecl))
+                // The `return` is load-bearing for `Void`-returning members
+                // under `.composition`: without a contextual result type the
+                // solver cannot infer `Output` for the generic spy subscript,
+                // and the compiler reports a "failed to produce diagnostic"
+                // internal error rather than a usable message.
+                ReturnStmtSyntax(expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess))
             case .asyncThrows:
                 ReturnStmtSyntax(
                     expression: TryExprSyntax(
                         expression: AwaitExprSyntax(
-                            expression: baseFunctionRequirementBody(funcDecl)
+                            expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess)
                         )
                     )
                 )
             case .throws:
                 ReturnStmtSyntax(
                     expression: TryExprSyntax(
-                        expression: baseFunctionRequirementBody(funcDecl)
+                        expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess)
                     )
                 )
             case .async:
                 ReturnStmtSyntax(
                     expression: AwaitExprSyntax(
-                        expression: baseFunctionRequirementBody(funcDecl)
+                        expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess)
                     )
                 )
             }
@@ -234,13 +264,18 @@ extension MockableGenerator {
     /// Generates the base function call for a function requirement body.
     ///
     /// This function creates a `FunctionCallExprSyntax` that calls the appropriate `adapt` function.
-    private static func baseFunctionRequirementBody(_ functionDecl: FunctionDeclSyntax) -> FunctionCallExprSyntax {
+    private static func baseFunctionRequirementBody(
+        _ functionDecl: FunctionDeclSyntax,
+        spyAccess: SpyAccess = .inherited
+    ) -> FunctionCallExprSyntax {
         let effectType = getFunctionEffectType(functionDecl)
         return adaptCall(
             effectType: effectType,
             requirementName: functionDecl.name,
             parameters: functionDecl.signature.parameterClause.parameters
-                .map({ ExprSyntax(DeclReferenceExprSyntax(baseName: $0.secondName ?? $0.firstName)) })
+                .map({ ExprSyntax(DeclReferenceExprSyntax(baseName: $0.secondName ?? $0.firstName)) }),
+            spyAccess: spyAccess,
+            isStatic: functionDecl.modifiers.contains(where: \.isStatic)
         )
     }
 
@@ -252,20 +287,21 @@ extension MockableGenerator {
     /// ```swift
     /// adapt(super.myMethod, param1)
     /// ```
-    private static func adaptCall(effectType: EffectType, requirementName: TokenSyntax, parameters: [ExprSyntax]) -> FunctionCallExprSyntax {
+    private static func adaptCall(
+        effectType: EffectType,
+        requirementName: TokenSyntax,
+        parameters: [ExprSyntax],
+        spyAccess: SpyAccess = .inherited,
+        isStatic: Bool = false
+    ) -> FunctionCallExprSyntax {
         let adaptingName = "adapt" + (effectType.rawValue.contains("Throws") ? "Throwing" : "")
         return FunctionCallExprSyntax(
-            calledExpression: DeclReferenceExprSyntax(
-                baseName: .identifier(adaptingName)
-            ),
+            calledExpression: spyAccess.adapterCallee(adaptingName),
             leftParen: .leftParenToken(),
             arguments: LabeledExprListSyntax {
-                // super.myMethodName
+                // super.myMethodName — or mock.myMethodName when composing
                 LabeledExprSyntax(
-                    expression: MemberAccessExprSyntax(
-                        base: SuperExprSyntax(),
-                        name: requirementName
-                    )
+                    expression: spyAccess.spyReference(requirementName, isStatic: isStatic)
                 )
 
                 // param1, param2... — or () when the requirement has no

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -34,7 +34,7 @@ extension MockableGenerator {
             } else if let subscriptDecl = member.decl.as(SubscriptDeclSyntax.self) {
                 declarations.append(DeclSyntax(subscriptRequirement(subscriptDecl, spyAccess: spyAccess)))
             } else if let initDecl = member.decl.as(InitializerDeclSyntax.self) {
-                declarations.append(DeclSyntax(initializerRequirement(initDecl)))
+                declarations.append(DeclSyntax(initializerRequirement(initDecl, spyAccess: spyAccess)))
 
             }
         }
@@ -50,8 +50,30 @@ extension MockableGenerator {
     ///     // ...
     /// }
     /// ```
+    ///
+    /// Under `.composition` the body is `fatalError(...)` instead of empty.
+    /// A composed mock inherits the superclass its protocol constrains it to,
+    /// and Swift requires every designated initializer to chain to `super.init`:
+    ///
+    /// ```
+    /// error: 'super.init' isn't called on all paths before returning from initializer
+    /// ```
+    ///
+    /// The macro cannot synthesize that call — it never sees the superclass, so
+    /// it cannot know which initializers exist or what to pass them. Emitting
+    /// `super.init()` is not a fix either: it fails the same way whenever the
+    /// superclass has no zero-arg initializer. A `Never`-returning call
+    /// satisfies the chaining rule without naming any initializer, and costs
+    /// nothing in practice — the generated `init` exists only to satisfy the
+    /// protocol requirement, and tests construct mocks through the zero-arg
+    /// `init()` the mock gets for free.
+    ///
+    /// The inheriting strategy keeps the empty body: `Mock` always has a
+    /// zero-arg initializer, so Swift inserts the `super.init()` call
+    /// implicitly and the requirement compiles as-is.
     static func initializerRequirement(
-        _ initDecl: InitializerDeclSyntax
+        _ initDecl: InitializerDeclSyntax,
+        spyAccess: SpyAccess = .inherited
     ) -> InitializerDeclSyntax {
         let modifiers = DeclModifierListSyntax {
             DeclModifierSyntax(name: .keyword(.required))
@@ -65,7 +87,9 @@ extension MockableGenerator {
             genericParameterClause: initDecl.genericParameterClause,
             signature: initDecl.signature,
             body: CodeBlockSyntax {
-
+                if case .composed = spyAccess {
+                    ExprSyntax(#"fatalError("init(...) is not implemented on generated mocks")"#)
+                }
             }
         )
     }

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -185,19 +185,21 @@ public enum MockableGenerator {
     /// }
     /// ```
     /// This function will return `true`.
+    ///
+    /// Subscripts count alongside functions and variables: a `static subscript`
+    /// generates members that read `staticMock`, so omitting it from this check
+    /// produced a mock referencing storage that was never declared.
     private static func hasStaticMembers(protocolDecl: ProtocolDeclSyntax) -> Bool {
-        for member in protocolDecl.memberBlock.members {
-            if let funcDecl = member.decl.as(FunctionDeclSyntax.self) {
-                if funcDecl.modifiers.contains(where: { $0.name.text == "static" }) {
-                    return true
-                }
-            } else if let varDecl = member.decl.as(VariableDeclSyntax.self) {
-                if varDecl.modifiers.contains(where: { $0.name.text == "static" }) {
-                    return true
-                }
+        protocolDecl.memberBlock.members.contains { member in
+            let modifiers: DeclModifierListSyntax?
+            switch member.decl.as(DeclSyntaxEnum.self) {
+            case .functionDecl(let decl): modifiers = decl.modifiers
+            case .variableDecl(let decl): modifiers = decl.modifiers
+            case .subscriptDecl(let decl): modifiers = decl.modifiers
+            default: modifiers = nil
             }
+            return modifiers?.contains(where: \.isStatic) ?? false
         }
-        return false
     }
 
     /// Extracts mock generation options from a protocol's attributes.

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -34,19 +34,25 @@ public enum MockableGenerator {
         } else if codeGenOptions.contains(.suffixMock) {
             mockName = protocolName + "Mock"
         } else {
-            // Default behavior if no specific option is provided
-            mockName = protocolName + "Mock"
+            // No naming option given — follow `.default` rather than assuming a
+            // suffix, so an options list that names only non-naming options
+            // (`[.composition]`) keeps the same name as a bare `@Mockable`.
+            mockName = MockableOptions.default.contains(.prefixMock)
+                ? "Mock" + protocolName
+                : protocolName + "Mock"
         }
 
         // Generate the spy properties and methods using SpyGenerator
+        let spyAccess: SpyAccess = codeGenOptions.contains(.composition) ? .composed : .inherited
         let genericParameters = associatedTypesToGenericArguments(
             protocolDecl: protocolDecl
         )
         let typeAliases = makeTypeAliases(protocolDecl)
-        let interactions = makeInteractions(protocolDecl: protocolDecl)
-        let conformanceRequirements = makeConformanceRequirements(for: protocolDecl)
+        let spyStorage = makeSpyStorage(protocolDecl: protocolDecl, spyAccess: spyAccess)
+        let interactions = makeInteractions(protocolDecl: protocolDecl, spyAccess: spyAccess)
+        let conformanceRequirements = makeConformanceRequirements(for: protocolDecl, spyAccess: spyAccess)
 
-        let members = separatedByBlankLines(typeAliases + interactions + conformanceRequirements)
+        let members = separatedByBlankLines(typeAliases + spyStorage + interactions + conformanceRequirements)
             .map { MemberBlockItemSyntax(decl: $0) }
 
         // Create the Mock struct
@@ -54,29 +60,10 @@ public enum MockableGenerator {
             name: TokenSyntax.identifier(mockName),
             genericParameterClause: genericParameters,
             inheritanceClause: InheritanceClauseSyntax(
-                inheritedTypes: [
-                    InheritedTypeSyntax(
-                        type: IdentifierTypeSyntax(
-                            name: .identifier("Mock")
-                        ),
-                        trailingComma: .commaToken()
-                    ),
-                    InheritedTypeSyntax(
-                        // `Mock` is `@unchecked Sendable`; subclasses must restate the
-                        // conformance to stay warning-free under Swift 6 concurrency.
-                        type: AttributedTypeSyntax(
-                            specifiers: [],
-                            attributes: [.attribute(
-                                AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("unchecked")))
-                            )],
-                            baseType: IdentifierTypeSyntax(name: TokenSyntax.identifier("Sendable"))
-                        ),
-                        trailingComma: .commaToken()
-                    ),
-                    InheritedTypeSyntax(
-                        type: IdentifierTypeSyntax(name: protocolDecl.name)
-                    )
-                ]
+                inheritedTypes: inheritedTypes(
+                    protocolDecl: protocolDecl,
+                    spyAccess: spyAccess
+                )
             ),
             memberBlock: MemberBlockSyntax(members: MemberBlockItemListSyntax(members))
         )
@@ -86,6 +73,85 @@ public enum MockableGenerator {
         })
 
         return [DeclSyntax(ifConfigDecl)]
+    }
+
+    /// Builds the generated mock's inheritance clause.
+    ///
+    /// Inheriting mocks are `Mock, @unchecked Sendable, <Protocol>`.
+    ///
+    /// Composing mocks instead restate the protocol's own inherited types first
+    /// — that is the whole point of the strategy, since a protocol carrying a
+    /// class constraint (`protocol Service: SomeBaseClass`) requires its
+    /// conformers to inherit that class, and the slot is taken by `Mock` under
+    /// the default strategy. Inherited *protocols* are harmless here: conforming
+    /// to the most-derived protocol already implies them.
+    ///
+    /// `MockProviding` is added so `verifyZeroInteractions` accepts the mock;
+    /// inheriting mocks get that conformance from `Mock` itself.
+    static func inheritedTypes(
+        protocolDecl: ProtocolDeclSyntax,
+        spyAccess: SpyAccess
+    ) -> InheritedTypeListSyntax {
+        // `Mock` is `@unchecked Sendable`; conformers must restate the
+        // conformance to stay warning-free under Swift 6 concurrency.
+        let uncheckedSendable = TypeSyntax(
+            AttributedTypeSyntax(
+                specifiers: [],
+                attributes: [.attribute(
+                    AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("unchecked")))
+                )],
+                baseType: IdentifierTypeSyntax(name: TokenSyntax.identifier("Sendable"))
+            )
+        )
+
+        var types: [TypeSyntax]
+        switch spyAccess {
+        case .inherited:
+            types = [
+                TypeSyntax(IdentifierTypeSyntax(name: .identifier("Mock"))),
+                uncheckedSendable,
+                TypeSyntax(IdentifierTypeSyntax(name: protocolDecl.name))
+            ]
+        case .composed:
+            let inherited = protocolDecl.inheritanceClause?.inheritedTypes
+                .map { TypeSyntax(stringLiteral: $0.type.trimmedDescription) } ?? []
+            types = inherited + [
+                TypeSyntax(IdentifierTypeSyntax(name: protocolDecl.name)),
+                TypeSyntax(IdentifierTypeSyntax(name: .identifier("MockProviding"))),
+                uncheckedSendable
+            ]
+        }
+
+        return InheritedTypeListSyntax(
+            types.enumerated().map { index, type in
+                InheritedTypeSyntax(
+                    type: type,
+                    trailingComma: index == types.count - 1 ? nil : .commaToken()
+                )
+            }
+        )
+    }
+
+    /// The stored properties a composing mock keeps its spies in.
+    ///
+    /// Empty for the inheriting strategy, which *is* its own storage.
+    ///
+    /// A static property is emitted only when the protocol has static
+    /// requirements: static members cannot reach an instance property, so they
+    /// need separate storage — the composed counterpart of `Mock.Super`.
+    static func makeSpyStorage(
+        protocolDecl: ProtocolDeclSyntax,
+        spyAccess: SpyAccess
+    ) -> [DeclSyntax] {
+        guard case .composed = spyAccess else { return [] }
+
+        var decls: [DeclSyntax] = [
+            "let \(raw: SpyAccess.storedPropertyName) = Mock()"
+        ]
+        if hasStaticMembers(protocolDecl: protocolDecl) {
+            decls.append("static let \(raw: SpyAccess.staticStoredPropertyName) = Mock()")
+        }
+        return decls
     }
 
     /// Inserts a blank line before every member but the first.

--- a/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
+++ b/Sources/MockableGenerator/SwiftSyntax+Extensions.swift
@@ -13,6 +13,86 @@ extension DeclModifierSyntax {
     }
 }
 
+/// How generated members reach the spies backing them.
+///
+/// The two strategies differ only in the expression naming a spy and in whether
+/// the `adapt` family is called as an instance or static method — everything
+/// else about a generated mock is identical, so the builders take this value
+/// and stay otherwise shared.
+public enum SpyAccess {
+    /// The mock inherits `Mock`: spies are `super.name`, adapters are instance
+    /// methods inherited from `Mock`.
+    case inherited
+    /// The mock holds a `Mock`: spies are `mock.name` (or `staticMock.name` in
+    /// a static member), adapters are `Mock`'s static methods, since a
+    /// composing type inherits nothing from `Mock`.
+    case composed
+
+    /// The name of the stored property holding the `Mock` in a composed mock.
+    static let storedPropertyName = "mock"
+
+    /// The name of the stored property holding the `Mock` that backs *static*
+    /// requirements in a composed mock.
+    ///
+    /// Static members cannot reach an instance property, so they need their own
+    /// storage. This mirrors what `Mock.Super` does for the inheriting strategy.
+    static let staticStoredPropertyName = "staticMock"
+
+    /// The expression a spy is looked up on, for a member of the given kind.
+    ///
+    /// Instance storage is spelled `self.mock` rather than a bare `mock`:
+    /// settable members read the spy inside an escaping closure, where Swift
+    /// requires explicit `self` (`reference to property 'mock' in closure
+    /// requires explicit use of 'self' to make capture semantics explicit`).
+    /// `super` never needed the qualification, so this has no inherited
+    /// counterpart. Static storage is a type member and needs no qualifier.
+    ///
+    /// - Parameter isStatic: Whether the member reading the spy is `static`.
+    func spyBase(isStatic: Bool) -> ExprSyntax {
+        switch self {
+        case .inherited:
+            return ExprSyntax(SuperExprSyntax())
+        case .composed where isStatic:
+            return ExprSyntax(
+                DeclReferenceExprSyntax(baseName: .identifier(Self.staticStoredPropertyName))
+            )
+        case .composed:
+            return ExprSyntax(
+                MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+                    name: .identifier(Self.storedPropertyName)
+                )
+            )
+        }
+    }
+
+    /// A `<base>.<name>` spy reference for a member of the given kind.
+    func spyReference(_ name: TokenSyntax, isStatic: Bool) -> ExprSyntax {
+        ExprSyntax(
+            MemberAccessExprSyntax(
+                base: spyBase(isStatic: isStatic),
+                name: name
+            )
+        )
+    }
+
+    /// The callee for an adapter call — bare for the inherited instance method,
+    /// `Mock.`-qualified for the static one a composing type must use.
+    func adapterCallee(_ adapterName: String) -> ExprSyntax {
+        switch self {
+        case .inherited:
+            return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(adapterName)))
+        case .composed:
+            return ExprSyntax(
+                MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .identifier("Mock")),
+                    name: .identifier(adapterName)
+                )
+            )
+        }
+    }
+}
+
 extension DeclModifierListSyntax {
     /// The modifiers with `mutating` and `nonmutating` removed.
     ///

--- a/Sources/SwiftMocking/MockProviding.swift
+++ b/Sources/SwiftMocking/MockProviding.swift
@@ -1,0 +1,33 @@
+//
+//  MockProviding.swift
+//  swift-mocking
+//
+
+/// A type that exposes the ``Mock`` backing its spies.
+///
+/// Generated mocks reach spy storage in one of two ways:
+///
+/// - By **inheriting** ``Mock`` — the default strategy, where `super.name`
+///   resolves the spy.
+/// - By **holding** one — the `@Mockable([.composition])` strategy, where
+///   `mock.name` resolves the spy. Required when the mock must inherit some
+///   other superclass, as it must for a protocol carrying a class constraint
+///   (`protocol Service: SomeBaseClass`).
+///
+/// Most of the API is unaffected by the difference, because ``Interaction``
+/// carries a ``Spy`` and never knows which type declared it. This protocol
+/// exists for the APIs that need the mock's *whole* spy set rather than one
+/// named requirement — ``verifyZeroInteractions(_:fileID:file:line:column:)`` —
+/// so they accept both strategies.
+///
+/// ``Mock`` conforms by returning itself, so inheriting mocks satisfy the
+/// requirement without generating anything.
+public protocol MockProviding {
+    /// The mock holding this type's spies.
+    var mock: Mock { get }
+}
+
+extension Mock: MockProviding {
+    /// An inheriting mock *is* its own spy storage.
+    public var mock: Mock { self }
+}

--- a/Sources/SwiftMocking/TestSupport.swift
+++ b/Sources/SwiftMocking/TestSupport.swift
@@ -283,19 +283,26 @@ public func <- <each Input, Eff: Effect, Output>(
 /// verifyZeroInteractions(anotherMock)
 /// ```
 ///
-/// - Parameter mock: A `Mock` object to verify has had no interactions.
+/// Accepts both generation strategies through ``MockProviding``: a mock that
+/// inherits ``Mock`` provides itself, and one generated with
+/// `@Mockable([.composition])` provides the ``Mock`` it holds.
+///
+/// - Parameter mock: A mock to verify has had no interactions.
 /// - Parameter file: The file where a verification failure is reported.
 /// - Parameter line: The line where a verification failure is reported.
 public func verifyZeroInteractions(
-    _ mock: Mock,
+    _ mock: some MockProviding,
     fileID: StaticString = #fileID,
     file: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column
 ) {
-    let totalInvocations = mock.spies.values.flatMap { $0 }.reduce(0) { $0 + $1.invocationCount }
+    let storage = mock.mock
+    let totalInvocations = storage.spies.values.flatMap { $0 }.reduce(0) { $0 + $1.invocationCount }
 
     if totalInvocations > 0 {
+        // The composing type, not the `Mock` it holds — `MockService` reads
+        // better in a failure than the bare `Mock` every composed mock shares.
         let mockTypeName = String(describing: type(of: mock))
         let location = SourceLocation(fileID: fileID, filePath: file, line: line, column: column)
         location.report("Expected zero interactions with \(mockTypeName) but found \(totalInvocations) invocation(s)")

--- a/Sources/SwiftMockingOptions/MockableOptions.swift
+++ b/Sources/SwiftMockingOptions/MockableOptions.swift
@@ -35,6 +35,31 @@ public struct MockableOptions: OptionSet, Sendable {
         rawValue: 1 << 1
     )
 
+    /// Generates a mock that *holds* a `Mock` instead of inheriting from one.
+    ///
+    /// The default strategy makes the mock a subclass of `Mock`, reaching spies
+    /// through `super`. That is impossible when the mock must already inherit
+    /// something else — most notably for a protocol carrying a class constraint:
+    ///
+    /// ```swift
+    /// @Mockable([.composition])
+    /// protocol ViewControllerService: SampleBase {
+    ///     func modified() -> Data
+    /// }
+    /// ```
+    ///
+    /// Swift permits only one superclass, so the generated mock inherits
+    /// `SampleBase` (as the protocol requires) and reaches spies through a
+    /// stored `mock` property instead. Without this option that protocol cannot
+    /// be mocked at all: the generated class fails with `requires that
+    /// 'MockViewControllerService' inherit from 'SampleBase'`.
+    ///
+    /// The generated mock conforms to `MockProviding`, so `verifyZeroInteractions`
+    /// works with either strategy.
+    public static let composition = MockableOptions(
+        rawValue: 1 << 2
+    )
+
     /// Initializes a `MockableOptions` instance with the given raw value.
     /// - Parameter rawValue: The raw integer value representing the option set.
     public init(rawValue: Int) {
@@ -58,6 +83,8 @@ public struct MockableOptions: OptionSet, Sendable {
                 combinedOptions.formUnion(.suffixMock)
             case "prefixMock":
                 combinedOptions.formUnion(.prefixMock)
+            case "composition":
+                combinedOptions.formUnion(.composition)
             case "": // Handle empty string if there are trailing commas or empty array
                 continue
             default:
@@ -73,6 +100,7 @@ public struct MockableOptions: OptionSet, Sendable {
         var names: [String] = []
         if contains(.prefixMock) { names.append("prefixMock") }
         if contains(.suffixMock) { names.append("suffixMock") }
+        if contains(.composition) { names.append("composition") }
         return names
     }
 }

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -34,6 +34,77 @@ final class MacroOptionsTests: MacroTestCase {
         }
     }
 
+    /// `.composition` makes the mock *hold* a `Mock` instead of inheriting one,
+    /// freeing the superclass slot for the class constraint the protocol
+    /// imposes. Note the mock inherits `SampleBase`, reaches spies through
+    /// `self.mock`, and calls the static `Mock.adapt` — a composing type
+    /// inherits no instance adapters.
+    func testCompositionOption() {
+        assertMacro {
+            """
+            @Mockable([.composition])
+            protocol MyService: SampleBase {
+                func doSomething()
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService: SampleBase {
+                func doSomething()
+            }
+
+            #if DEBUG
+            class MockMyService: SampleBase, MyService, MockProviding, @unchecked Sendable {
+                let mock = Mock()
+
+                func doSomething() -> Interaction<Void, None, Void> {
+                    Interaction(.any, spy: self.mock.doSomething)
+                }
+
+                func doSomething() {
+                    return Mock.adapt(self.mock.doSomething, ())
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    /// A protocol with static requirements gets a second `Mock` for them:
+    /// static members cannot reach an instance property.
+    func testCompositionOptionWithStaticRequirement() {
+        assertMacro {
+            """
+            @Mockable([.composition])
+            protocol MyService: SampleBase {
+                static func reset()
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService: SampleBase {
+                static func reset()
+            }
+
+            #if DEBUG
+            class MockMyService: SampleBase, MyService, MockProviding, @unchecked Sendable {
+                let mock = Mock()
+
+                static let staticMock = Mock()
+
+                static func reset() -> Interaction<Void, None, Void> {
+                    Interaction(.any, spy: staticMock.reset)
+                }
+
+                static func reset() {
+                    return Mock.adapt(staticMock.reset, ())
+                }
+            }
+            #endif
+            """
+        }
+    }
+
     func testSuffixMockOption() {
         assertMacro {
             """

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -105,6 +105,38 @@ final class MacroOptionsTests: MacroTestCase {
         }
     }
 
+    /// A composed mock inherits its protocol's required superclass, so its
+    /// initializer must chain to `super.init`. The macro never sees that
+    /// superclass and so cannot synthesize the call — `fatalError` satisfies
+    /// the rule without naming an initializer. The inheriting strategy keeps an
+    /// empty body, since `Mock` always has a zero-argument initializer.
+    func testCompositionOptionWithInitializerRequirement() {
+        assertMacro {
+            """
+            @Mockable([.composition])
+            protocol MyService: SampleBase {
+                init(value: Int)
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService: SampleBase {
+                init(value: Int)
+            }
+
+            #if DEBUG
+            class MockMyService: SampleBase, MyService, MockProviding, @unchecked Sendable {
+                let mock = Mock()
+
+                required init(value: Int) {
+                    fatalError("init(...) is not implemented on generated mocks")
+                }
+            }
+            #endif
+            """
+        }
+    }
+
     func testSuffixMockOption() {
         assertMacro {
             """

--- a/Tests/SwiftMockingTests/CompositionShapeMatrixTests.swift
+++ b/Tests/SwiftMockingTests/CompositionShapeMatrixTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import SwiftMocking
+
+// MARK: - Shape matrix
+//
+// One class-constrained protocol per generation-relevant shape, each mocked with
+// `.composition`. Their value is largely in *compiling*: the composed strategy
+// rewrites every spy reference and adapter call, so a shape that the default
+// strategy handles can still break here. Snapshot tests cannot catch that — the
+// generated text looks correct and simply fails to build, which is how the
+// initializer bug below went unnoticed.
+
+/// A superclass with a zero-argument initializer.
+class ShapeBase {
+    init() {}
+}
+
+/// A superclass *without* a zero-argument initializer.
+///
+/// This is the case that exposed the initializer bug: Swift inserts an implicit
+/// `super.init()` only when the superclass has one, so a mock whose body never
+/// chains to `super.init` compiles against `ShapeBase` but not against this.
+class ConfiguredBase {
+    init(config: Int) {}
+}
+
+@Mockable([.composition])
+protocol AsyncThrowingShape: ShapeBase {
+    func fetch(from id: String) async throws -> Data
+}
+
+@Mockable([.composition])
+protocol VariadicShape: ShapeBase {
+    func record(_ values: String...)
+}
+
+@Mockable([.composition])
+protocol GenericMethodShape: ShapeBase {
+    func encode<T: Encodable>(_ value: T) -> Data
+}
+
+@Mockable([.composition])
+protocol SubscriptShape: ShapeBase {
+    subscript(index: Int) -> String { get }
+}
+
+@Mockable([.composition])
+protocol SettableSubscriptShape: ShapeBase {
+    subscript(row: Int, column: Int) -> String { get set }
+}
+
+@Mockable([.composition])
+protocol EscapingClosureShape: ShapeBase {
+    func execute(completion: @escaping (String) -> Void)
+}
+
+@Mockable([.composition])
+protocol StaticShape: ShapeBase {
+    static func reset() -> Int
+}
+
+@Mockable([.composition])
+protocol InitializerShape: ConfiguredBase {
+    init(value: Int)
+}
+
+/// Exercises each shape in the matrix above.
+///
+/// Every test here would have passed as a no-op if the file merely compiled, so
+/// each one also round-trips the mock — stub, call through a protocol-typed
+/// reference, verify — to prove the composed spy wiring is connected and not
+/// just syntactically valid.
+final class CompositionShapeMatrixTests: XCTestCase {
+    func testAsyncThrowing() async throws {
+        let mock = MockAsyncThrowingShape()
+        when(mock.fetch(from: .any)).thenReturn(Data([1]))
+
+        let service: AsyncThrowingShape = mock
+        let result = try await service.fetch(from: "id")
+
+        XCTAssertEqual(Array(result), [1])
+        verify(mock.fetch(from: .equal("id"))).called(1)
+    }
+
+    func testVariadic() {
+        let mock = MockVariadicShape()
+        let service: VariadicShape = mock
+
+        service.record("a", "b")
+
+        verify(mock.record(.equal("a"), .equal("b"))).called(1)
+    }
+
+    func testGenericMethod() {
+        let mock = MockGenericMethodShape()
+        when(mock.encode(.any(Int.self))).thenReturn(Data([2]))
+
+        let result: Data = mock.encode(7)
+
+        XCTAssertEqual(Array(result), [2])
+        verify(mock.encode(.any(Int.self))).called(1)
+    }
+
+    func testSubscriptGetter() {
+        let mock = MockSubscriptShape()
+        when(mock[.equal(1)]).thenReturn("one")
+
+        let service: SubscriptShape = mock
+
+        XCTAssertEqual(service[1], "one")
+        verify(mock[.equal(1)]).called(1)
+    }
+
+    /// Settable members read their spy inside an escaping closure, the case that
+    /// forces `self.mock` rather than a bare `mock` in generated code.
+    func testSettableSubscript() {
+        let mock = MockSettableSubscriptShape()
+        when(mock[.any, .any]).thenReturn("read")
+        var service: SettableSubscriptShape = mock
+
+        service[1, 2] = "written"
+        let read = service[1, 2]
+
+        XCTAssertEqual(read, "read")
+        verify(mock[.equal(1), .equal(2)]).called(1)
+        // Annotated for the same reason as the multi-index case in
+        // `SubscriptInteractionTests`: `<-` returns
+        // `Interaction<repeat each Input, Output, None, Void>`, and splitting a
+        // concrete `Int, Int, String` back into `each Input` plus `Output` is
+        // not inferable. Pre-existing, not specific to `.composition`.
+        let write: Interaction<Int, Int, String, None, Void> =
+            mock[.equal(1), .equal(2)] <- "written"
+        verify(write).called(1)
+    }
+
+    func testEscapingClosureParameter() {
+        let mock = MockEscapingClosureShape()
+        let service: EscapingClosureShape = mock
+
+        service.execute(completion: { _ in })
+
+        verify(mock.execute(completion: .any)).called(1)
+    }
+
+    func testStatic() {
+        MockStaticShape.staticMock.clear()
+        when(MockStaticShape.reset()).thenReturn(3)
+
+        let service: StaticShape.Type = MockStaticShape.self
+
+        XCTAssertEqual(service.reset(), 3)
+        verify(MockStaticShape.reset()).called(1)
+    }
+
+    /// A composed mock inherits its protocol's required superclass, so its
+    /// initializer must chain to `super.init`. The macro cannot synthesize that
+    /// call — it never sees the superclass — so the body is `fatalError`, which
+    /// satisfies the chaining rule without naming an initializer.
+    ///
+    /// This test is a compile-time assertion: before the fix this file did not
+    /// build, failing with `'super.init' isn't called on all paths before
+    /// returning from initializer`. The generated `init` is never called, so
+    /// there is no runtime behaviour to assert.
+    func testInitializerRequirementCompiles() {
+        XCTAssertTrue((MockInitializerShape.self as Any) is ConfiguredBase.Type)
+    }
+}

--- a/Tests/SwiftMockingTests/CompositionShapeMatrixTests.swift
+++ b/Tests/SwiftMockingTests/CompositionShapeMatrixTests.swift
@@ -59,6 +59,17 @@ protocol StaticShape: ShapeBase {
     static func reset() -> Int
 }
 
+/// A protocol whose *only* static member is a subscript.
+///
+/// `hasStaticMembers` originally inspected functions and variables but not
+/// subscripts, so this shape generated members reading `staticMock` without
+/// declaring it. Static functions masked the gap — this protocol deliberately
+/// has none.
+@Mockable([.composition])
+protocol StaticSubscriptShape: ShapeBase {
+    static subscript(index: Int) -> String { get }
+}
+
 @Mockable([.composition])
 protocol InitializerShape: ConfiguredBase {
     init(value: Int)
@@ -150,6 +161,19 @@ final class CompositionShapeMatrixTests: XCTestCase {
 
         XCTAssertEqual(service.reset(), 3)
         verify(MockStaticShape.reset()).called(1)
+    }
+
+    /// Regression: a protocol whose only static member is a subscript must
+    /// still get `staticMock`. Before the fix this file did not compile —
+    /// `cannot find 'staticMock' in scope`.
+    func testStaticSubscript() {
+        MockStaticSubscriptShape.staticMock.clear()
+        when(MockStaticSubscriptShape[.equal(1)]).thenReturn("one")
+
+        let service: StaticSubscriptShape.Type = MockStaticSubscriptShape.self
+
+        XCTAssertEqual(service[1], "one")
+        verify(MockStaticSubscriptShape[.equal(1)]).called(1)
     }
 
     /// A composed mock inherits its protocol's required superclass, so its

--- a/Tests/SwiftMockingTests/CompositionStrategyTests.swift
+++ b/Tests/SwiftMockingTests/CompositionStrategyTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import SwiftMocking
+
+/// A class a protocol can constrain its conformers to.
+class SampleBase {
+    init() {}
+}
+
+/// The motivating case: a protocol carrying a **class constraint**.
+///
+/// Conformers must inherit `SampleBase`, and the default strategy needs that
+/// same slot for `Mock`. Swift permits one superclass, so without
+/// `.composition` the generated mock fails to compile with `requires that
+/// 'MockViewControllerService' inherit from 'SampleBase'` — and no hand-edit
+/// rescues it, unlike protocol inheritance where marking the parent `@Mockable`
+/// works around the limitation.
+@Mockable([.composition])
+protocol ViewControllerService: SampleBase {
+    func modified() -> Data
+    func ping()
+    var name: String { get }
+    var flag: Bool { get set }
+    static func shared() -> Int
+}
+
+/// Tests for `@Mockable([.composition])`.
+///
+/// These are primarily *compile-time* assertions: the snapshot tests in
+/// `SwiftMockingMacrosTests` compare generated text and cannot catch output
+/// that is well-formed but rejected by the compiler. That gap is what hid the
+/// `mutating` bug, so the strategy is exercised here against a real protocol.
+final class CompositionStrategyTests: XCTestCase {
+    func testMethodStubbingAndVerification() {
+        let mock = MockViewControllerService()
+        when(mock.modified()).thenReturn(Data([1, 2, 3]))
+
+        let service: ViewControllerService = mock
+        let result = service.modified()
+
+        XCTAssertEqual(Array(result), [1, 2, 3])
+        verify(mock.modified()).called(1)
+    }
+
+    /// `Void` returns are the inference-sensitive case under composition: with
+    /// no contextual result type the solver cannot infer the spy's `Output`.
+    /// The generated `return` is what anchors it.
+    func testVoidReturningMethodIsRecorded() {
+        let mock = MockViewControllerService()
+        let service: ViewControllerService = mock
+
+        service.ping()
+
+        verify(mock.ping()).called(1)
+    }
+
+    func testPropertyGetter() {
+        let mock = MockViewControllerService()
+        when(mock.name()).thenReturn("composed")
+
+        let service: ViewControllerService = mock
+
+        XCTAssertEqual(service.name, "composed")
+        verify(mock.name()).called(1)
+    }
+
+    /// Settable members read their spy inside an escaping closure, where the
+    /// composed strategy must spell `self.mock` — a bare `mock` is rejected
+    /// with `requires explicit use of 'self'`.
+    func testSettablePropertyRecordsReadsAndWrites() {
+        let mock = MockViewControllerService()
+        when(mock.flag()).thenReturn(true)
+        var service: ViewControllerService = mock
+
+        service.flag = false
+        let read = service.flag
+
+        XCTAssertTrue(read)
+        verify(mock.flag() <- .equal(false)).called(1)
+    }
+
+    /// Static requirements resolve through the separate `staticMock` storage,
+    /// since a static member cannot reach an instance property.
+    func testStaticRequirement() {
+        MockViewControllerService.staticMock.clear()
+        when(MockViewControllerService.shared()).thenReturn(42)
+
+        let service: ViewControllerService.Type = MockViewControllerService.self
+
+        XCTAssertEqual(service.shared(), 42)
+        verify(MockViewControllerService.shared()).called(1)
+    }
+
+    /// `verifyZeroInteractions` takes a `MockProviding`, so it accepts a
+    /// composed mock directly rather than requiring `mock.mock`.
+    func testVerifyZeroInteractionsAcceptsComposedMock() {
+        let mock = MockViewControllerService()
+
+        verifyZeroInteractions(mock)
+    }
+
+    /// The composed mock still satisfies its class constraint.
+    func testMockIsUsableAsItsRequiredSuperclass() {
+        let mock = MockViewControllerService()
+
+        XCTAssertTrue((mock as Any) is SampleBase)
+    }
+}

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swift-mocking
-description: Use when writing Swift tests with the SwiftMocking library — creating @Mockable mocks, stubbing with when/verify, matching arguments, or hand-writing mocks (protocol inheritance chains, mocking classes).
+description: Use when writing Swift tests with the SwiftMocking library — creating @Mockable mocks, stubbing with when/verify, matching arguments, class-constrained protocols (@Mockable([.composition])), or hand-writing mocks (protocol inheritance chains, mocking classes).
 ---
 
 # SwiftMocking
@@ -10,7 +10,16 @@ Mocking for Swift protocols: `@Mockable` generates mock classes; `when(...)` stu
 The macro is not the only entry point. Two escape hatches cover everything it can't reach, and both are fully supported (see **spies-and-composition.md**):
 
 - **`Spy` used directly** — a standalone recorder needing no `Mock` subclass and no macro. This is how you mock **classes**, which `@Mockable` cannot touch at all: subclass the class and back each override with a `Spy`.
-- **Composition over inheritance** — hold a `let mock = Mock()` property instead of inheriting from `Mock`. `Mock`'s `@dynamicMemberLookup` subscript is `public`, so `mock.name` resolves spies from outside the class. Required when the type already has a superclass (`UIViewController`, a legacy base class) or isn't a class at all (**struct**, **actor**). Substitute `super.name` → `mock.name` and `adapt(...)` → `Mock.adapt(...)`; everything else in manual-mocking.md is unchanged.
+- **Composition over inheritance** — hold a `let mock = Mock()` property instead of inheriting from `Mock`. `Mock`'s `@dynamicMemberLookup` subscript is `public`, so `mock.name` resolves spies from outside the class. Required when the type already has a superclass (`UIViewController`, a legacy base class) or isn't a class at all (**struct**, **actor**). Substitute `super.name` → `self.mock.name` and `adapt(...)` → `Mock.adapt(...)`; everything else in manual-mocking.md is unchanged.
+
+**The macro generates the composed form itself** with `@Mockable([.composition])` — no hand-writing — when the blocker is a protocol whose conformers must inherit a class:
+
+```swift
+@Mockable([.composition])
+protocol ViewControllerService: SampleBase { ... }
+```
+
+Hand-write composition only for what the macro still can't express: **structs**, **actors**, and mocking a **concrete class**.
 
 ## When to use what
 
@@ -18,8 +27,9 @@ The macro is not the only entry point. Two escape hatches cover everything it ca
 |---|---|
 | Protocol has no inheritance; need a mock | `@Mockable protocol P {...}` → use `PMock()` |
 | Protocol inherits another protocol with members | **manual-mocking.md** (macro cannot do this) |
+| **Protocol constrained to a class** (`protocol P: SomeClass`) | `@Mockable([.composition])` — the macro handles it |
 | **Mocking a class** (no protocol available) | **spies-and-composition.md** — subclass + raw `Spy` |
-| **Can't inherit `Mock`** (existing superclass, struct, actor) | **spies-and-composition.md** — `let mock = Mock()` |
+| **Can't inherit `Mock`** (struct, actor, or a hand-written type with a superclass) | **spies-and-composition.md** — `let mock = Mock()` |
 | Mocking without any protocol (closure/TCA dependencies) | usage.md / spies-and-composition.md — `Spy` + `adapt` |
 | Stubbing/verifying settable properties or subscripts (`{ get set }`) | usage.md — *Properties & subscripts*; hand-written shape in manual-mocking.md |
 | Need mock source without the macro (plugin unavailable, codegen, review) | `mockable` CLI (below) when available; hand-writing per manual-mocking.md is always valid |
@@ -51,7 +61,7 @@ echo 'protocol P { func price(_ item: String) throws -> Int }' | mockable
 
 Invoke as `mockable` when it is on `PATH`; otherwise `.build/release/mockable` inside a swift-mocking checkout (build once with `swift build -c release --product mockable`, then optionally copy the binary onto `PATH`).
 
-- Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin.
+- Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin. `[.composition]` works here too — the fastest way to see the composed shape for a given protocol.
 - Default output keeps the macro's `#if DEBUG` wrapper; pass `--no-debug-wrap` when pasting into a test target (DEBUG is per build configuration — a wrapped mock vanishes under `swift test -c release`).
 - A stderr warning about inherited requirements means the output will not conform — hand-write per manual-mocking.md instead.
 - Output keeps the macro's zero-arg/property-getter shape: `when(...)` silently stubs a disconnected spy, and `verify(...)` reports zero calls for those members — apply the pinned-spy fix from manual-mocking.md before relying on them.
@@ -93,8 +103,10 @@ verify(mock.price(.equal("apple"))).called(1)
 ## Known sharp edges
 
 - `@Mockable` on `protocol B: A` → compile error `does not conform to protocol 'A'` (inherited requirements never generated). Hand-write per manual-mocking.md.
+- `@Mockable` on `protocol P: SomeClass` → `requires that 'MockP' inherit from 'SomeClass'`. This is a **class constraint**, not protocol inheritance, and no hand-edit fixes the default output — the mock needs its superclass slot for `SomeClass`, and the default strategy needs it for `Mock`. Add `[.composition]`. The option is opt-in: the macro can't tell a class from a protocol by name, so it never infers it.
 - `@Mockable` only accepts **protocols** — never a class. To fake a class, subclass it and back overrides with raw `Spy` properties (spies-and-composition.md). `final` classes/members can't be faked either way; extract a protocol.
 - In a **composed** mock, plain `adapt(...)` doesn't resolve — it's an instance method on `Mock` and you didn't inherit it. Use the static `Mock.adapt(...)` / `Mock.adaptThrowing(...)`. Likewise `clear()` becomes `mock.clear()`.
+- Hand-written composed mocks must spell **`self.mock.name`**, not a bare `mock.name`, wherever the spy is read inside a closure — settable members do exactly that, and Swift rejects the bare form with `requires explicit use of 'self' to make capture semantics explicit`. `super` never needed the qualifier. `[.composition]` output already does this.
 - Zero-arg members (`func start()`, property getters): `when(mock.getX()).thenReturn(v)` does not reach the runtime member in macro-generated mocks. Manual mocks fix this with the pinned-spy pattern.
 - Stub API is `thenReturn` / `thenThrow` / `do` — there is no `.then`.
 - Spy names come from the requirement, ignoring argument labels: methods use their name, subscripts are namespaced as `subscript`+ParameterNames (`subscript(row:column:)` → `subscriptRowColumn`), settable members add `set`+Name. The prefix keeps a subscript from colliding with a method or variable of the same name. The compiler already rejects most same-key cases (two subscripts differing only by argument label, or a `var x` beside a `func x()`, are both invalid redeclarations); the one that compiles but mocks incorrectly is two *methods* differing only by argument label (`fetch(id:)`/`fetch(name:)`), which silently share a spy — rename one or vary the parameter types. Same-name/different-signature overloads are fine.

--- a/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
+++ b/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
@@ -420,7 +420,6 @@ public enum UntilError : Error, Sendable, CustomStringConvertible {
     get
   }
 }
-}
 extension Return where Effects == None {
 }
 extension Return where Effects == Async {
@@ -436,8 +435,6 @@ public struct SourceLocation : Sendable {
   public static func capture(fileID: StaticString = #fileID, filePath: StaticString = #filePath, line: UInt = #line, column: UInt = #column) -> SourceLocation {
         SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
     }
-    get
-  }
 }
 public class Spy<each Input, Effects, Output> : AnySpy, @unchecked Sendable where Effects : Effect {
   public var invocations: [Invocation<repeat each Input>] {

--- a/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
+++ b/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
@@ -168,7 +168,7 @@ extension Arrange where Eff == AsyncThrows {
 public class Assert<each Input, Eff, Output> where Eff : Effect {
   public init(invocationMatcher: InvocationMatcher<repeat each Input>? = nil, spy: Spy<repeat each Input, Eff, Output>)
   public func assert(_ matcher: ArgMatcher<Int>?) throws
-  public func neverCalled(file: StaticString = #filePath, line: UInt = #line)
+  public func neverCalled(fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
 }
 extension Assert where Eff == Throws {
   public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) throws
@@ -373,6 +373,14 @@ extension Mock {
   public func clear()
   public static func clear()
 }
+public protocol MockProviding {
+  var mock: Mock { get }
+}
+extension Mock : MockProviding {
+  public var mock: Mock {
+    get
+  }
+}
 public enum MockScope {
   public static let $invocationRecorder: TaskLocal<InvocationRecorder>
   public static var invocationRecorder: InvocationRecorder {
@@ -406,11 +414,9 @@ public struct MockingError : Error, Equatable, Sendable {
   public static func unfulfilledCallCount(_ actual: Int) -> MockingError
   public static let noMatchingInvocations: MockingError
 }
-public enum UntilError : Error, Sendable {
-  case timeout
-  public static func == (a: UntilError, b: UntilError) -> Bool
-  public func hash(into hasher: inout Hasher)
-  public var hashValue: Int {
+public enum UntilError : Error, Sendable, CustomStringConvertible {
+  case timeout(method: String? = nil, duration: Duration? = nil)
+  public var description: String {
     get
   }
 }
@@ -425,6 +431,13 @@ public struct SettableInteraction<each Input, Eff, Output> where Eff : Effect {
   public func set(_ newValue: ArgMatcher<Output>) -> Interaction<repeat each Input, Output, None, Void>
 }
 extension SettableInteraction : Sendable where repeat each Input : Sendable, Output : Sendable {
+}
+public struct SourceLocation : Sendable {
+  public static func capture(fileID: StaticString = #fileID, filePath: StaticString = #filePath, line: UInt = #line, column: UInt = #column) -> SourceLocation {
+        SourceLocation(fileID: fileID, filePath: filePath, line: line, column: column)
+    }
+    get
+  }
 }
 public class Spy<each Input, Effects, Output> : AnySpy, @unchecked Sendable where Effects : Effect {
   public var invocations: [Invocation<repeat each Input>] {
@@ -546,30 +559,28 @@ public func verify<each Input, Eff, Output>(_ interaction: Interaction<repeat ea
 public func verify<each Input, Eff, Output>(_ interaction: (()) -> Interaction<repeat each Input, Eff, Output>) -> Assert<repeat each Input, Eff, Output> where Eff : Effect
 public func verify<each Input, Eff, Output>(_ interaction: SettableInteraction<repeat each Input, Eff, Output>) -> Assert<repeat each Input, Eff, Output> where Eff : Effect
 public func verify<each Input, Eff, Output>(_ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>) -> Assert<repeat each Input, Eff, Output> where Eff : Effect
-public func verifyInOrder(_ verifiables: [any CrossSpyVerifiable], file: StaticString = #filePath, line: UInt = #line)
-public func verifyInOrder(@CrossSpyVerificationBuilder _ builder: () -> [any CrossSpyVerifiable], file: StaticString = #filePath, line: UInt = #line)
-public func verifyNever<each Input, Eff, Output>(_ interaction: Interaction<repeat each Input, Eff, Output>, file: StaticString = #filePath, line: UInt = #line) where Eff : Effect
-public func verifyNever<each Input, Eff, Output>(_ interaction: (()) -> Interaction<repeat each Input, Eff, Output>, file: StaticString = #filePath, line: UInt = #line) where Eff : Effect
-public func verifyNever<each Input, Eff, Output>(_ interaction: SettableInteraction<repeat each Input, Eff, Output>, file: StaticString = #filePath, line: UInt = #line) where Eff : Effect
-public func verifyNever<each Input, Eff, Output>(_ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>, file: StaticString = #filePath, line: UInt = #line) where Eff : Effect
+public func verifyInOrder(_ verifiables: [any CrossSpyVerifiable], fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
+public func verifyInOrder(@CrossSpyVerificationBuilder _ builder: () -> [any CrossSpyVerifiable], fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
+public func verifyNever<each Input, Eff, Output>(_ interaction: Interaction<repeat each Input, Eff, Output>, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) where Eff : Effect
+public func verifyNever<each Input, Eff, Output>(_ interaction: (()) -> Interaction<repeat each Input, Eff, Output>, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) where Eff : Effect
+public func verifyNever<each Input, Eff, Output>(_ interaction: SettableInteraction<repeat each Input, Eff, Output>, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) where Eff : Effect
+public func verifyNever<each Input, Eff, Output>(_ interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) where Eff : Effect
 infix operator <- : AssignmentPrecedence
 public func <- <each Input, Eff, Output>(interaction: SettableInteraction<repeat each Input, Eff, Output>, newValue: ArgMatcher<Output>) -> Interaction<repeat each Input, Output, None, Void> where Eff : Effect
 public func <- <each Input, Eff, Output>(interaction: (()) -> SettableInteraction<repeat each Input, Eff, Output>, newValue: ArgMatcher<Output>) -> Interaction<repeat each Input, Output, None, Void> where Eff : Effect
-public func verifyZeroInteractions(_ mock: Mock, file: StaticString = #filePath, line: UInt = #line)
+public func verifyZeroInteractions(_ mock: some MockProviding, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
 public func until<each Input, Output>(_ interaction: Interaction<repeat each Input, None, Output>, timeout: Duration = .seconds(1)) async throws where repeat each Input : Sendable
 public func until<each Input, Output>(_ interaction: Interaction<repeat each Input, Async, Output>, timeout: Duration = .seconds(1)) async throws where repeat each Input : Sendable
 public func until<each Input, Output>(_ interaction: Interaction<repeat each Input, AsyncThrows, Output>, timeout: Duration = .seconds(1)) async throws where repeat each Input : Sendable
 extension Assert {
-  public func called(_ countMatcher: ArgMatcher<Int>? = nil, file: StaticString = #filePath, line: UInt = #line)
+  public func called(_ countMatcher: ArgMatcher<Int>? = nil, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
 }
 extension Assert {
-  public func captured(_ inspector: @escaping (repeat each Input) throws -> Void, file: StaticString = #filePath, line: UInt = #line)
+  public func captured(_ inspector: @escaping (repeat each Input) throws -> Void, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
 }
 extension Assert where Eff == Throws {
-  public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, file: StaticString = #filePath, line: UInt = #line)
+  public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
 }
 extension Assert where Eff == AsyncThrows {
-  public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, file: StaticString = #filePath, line: UInt = #line) async
+  public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) async
 }
-extension UntilError : Equatable {}
-extension UntilError : Hashable {}

--- a/skills/swift-mocking/spies-and-composition.md
+++ b/skills/swift-mocking/spies-and-composition.md
@@ -138,13 +138,13 @@ protocol ViewControllerService: SampleBase {
 }
 ```
 
-Without the option this protocol **cannot be mocked at all**. Conformers must inherit `SampleBase`, the default strategy needs that same slot for `Mock`, and Swift allows one superclass:
+Without the option, the **default `@Mockable` output cannot conform** to this protocol. Conformers must inherit `SampleBase`, the default strategy needs that same slot for `Mock`, and Swift allows one superclass:
 
-```
+```text
 error: 'ViewControllerService' requires that 'MockViewControllerService' inherit from 'SampleBase'
 ```
 
-Unlike protocol inheritance — where marking the parent `@Mockable` is a workaround — no hand-edit rescues the default output here.
+Unlike protocol inheritance — where marking the parent `@Mockable` is a workaround — no edit to the *generated* output rescues it. Hand-writing the composed mock below is still a valid alternative; `[.composition]` just does it for you.
 
 The generated mock inherits the required superclass and holds a `Mock`:
 
@@ -176,7 +176,7 @@ Points worth knowing:
 - **`MockProviding`** is added so `verifyZeroInteractions(mock)` accepts the mock directly (see below).
 - Usage is identical to any other mock — `when`, `verify`, matchers, settable members all behave the same.
 
-Everything after this point is the **hand-written** recipe, for the cases the macro still can't express: structs, actors, and mocking a concrete class.
+Everything after this point is the **hand-written** recipe: structs, actors, types that already have a superclass, and mocking a concrete class. It stays valid for class-constrained protocols too — `[.composition]` just saves you writing it.
 
 ### Hand-written composition
 
@@ -212,7 +212,7 @@ This is the manual-mocking.md recipe with exactly **two mechanical substitutions
 
 **Spell it `self.mock.load`, not `mock.load`.** A bare `mock` works in a plain method body, but settable members read the spy inside an escaping closure, where Swift demands explicit `self`:
 
-```
+```text
 error: reference to property 'mock' in closure requires explicit use of 'self' to make capture semantics explicit
 ```
 

--- a/skills/swift-mocking/spies-and-composition.md
+++ b/skills/swift-mocking/spies-and-composition.md
@@ -7,14 +7,17 @@ Two escape hatches for everything `@Mockable` cannot reach. Both are fully suppo
 
 Every example below was compiled and executed against this package.
 
+**Check first whether the macro can do it for you.** `@Mockable([.composition])` generates the composed shape automatically for a protocol constrained to a class (`protocol P: SomeClass`) — see §Macro-generated composition. The hand-written recipe below is for what the macro still can't express.
+
 ## Decision table
 
 | Situation | Technique |
 |---|---|
 | Protocol, no inheritance | `@Mockable` (nothing here needed) |
 | Protocol inheritance chain | manual-mocking.md (subclass `Mock`) |
+| **Protocol constrained to a class** (`protocol P: SomeClass`) | `@Mockable([.composition])` — macro-generated, no hand-writing |
 | **Mocking a class** (`class RemoteLoader`, no protocol) | Subclass it, back overrides with raw `Spy` — §Raw spies |
-| **Type already has a superclass** (`UIViewController`, `RemoteLoader`) | Composition — §Composition |
+| **Hand-written type that already has a superclass** (`UIViewController`) | Composition — §Composition |
 | **Struct or actor conforming to a protocol** | Composition (can't inherit at all) |
 | Closure / TCA-style dependency | Raw `Spy` + `adapt(spy)` — usage.md also covers this |
 | Final class you can't subclass | Extract a protocol, or wrap it — §Limits |
@@ -120,6 +123,63 @@ Prefer the global `when`/`verify` in tests: they report failures through IssueRe
 
 ## Part 2 — Composition instead of inheritance
 
+### Macro-generated composition
+
+Before hand-writing anything, check whether `@Mockable([.composition])` covers your case. It does when the protocol is **constrained to a class**:
+
+```swift
+class SampleBase { init() {} }
+
+@Mockable([.composition])
+protocol ViewControllerService: SampleBase {
+    func load(_ id: String) throws -> String
+    var flag: Bool { get set }
+    static func reset()
+}
+```
+
+Without the option this protocol **cannot be mocked at all**. Conformers must inherit `SampleBase`, the default strategy needs that same slot for `Mock`, and Swift allows one superclass:
+
+```
+error: 'ViewControllerService' requires that 'MockViewControllerService' inherit from 'SampleBase'
+```
+
+Unlike protocol inheritance — where marking the parent `@Mockable` is a workaround — no hand-edit rescues the default output here.
+
+The generated mock inherits the required superclass and holds a `Mock`:
+
+```swift
+class MockViewControllerService: SampleBase, ViewControllerService, MockProviding, @unchecked Sendable {
+    let mock = Mock()
+    static let staticMock = Mock()          // only when the protocol has static requirements
+
+    func load(_ id: ArgMatcher<String>) -> Interaction<String, Throws, String> {
+        Interaction(id, spy: self.mock.load)
+    }
+    func load(_ id: String) throws -> String {
+        return try Mock.adaptThrowing(self.mock.load, id)
+    }
+
+    static func reset() -> Interaction<Void, None, Void> {
+        Interaction(.any, spy: staticMock.reset)
+    }
+    static func reset() {
+        return Mock.adapt(staticMock.reset, ())
+    }
+}
+```
+
+Points worth knowing:
+
+- **Opt-in only.** The macro cannot tell a class from a protocol by name, so it never infers the strategy — you hit the error first, then add the option.
+- **Statics get their own storage.** A static member can't reach an instance property, so `staticMock` is emitted when needed. It's the composed counterpart of `Mock.Super`.
+- **`MockProviding`** is added so `verifyZeroInteractions(mock)` accepts the mock directly (see below).
+- Usage is identical to any other mock — `when`, `verify`, matchers, settable members all behave the same.
+
+Everything after this point is the **hand-written** recipe, for the cases the macro still can't express: structs, actors, and mocking a concrete class.
+
+### Hand-written composition
+
 `Mock`'s power comes from its `@dynamicMemberLookup` subscript, and **that subscript is `public`**. So `mock.someName` resolves a lazily-created spy from *outside* the class too — you do not have to be a subclass:
 
 ```swift
@@ -145,10 +205,18 @@ This is the manual-mocking.md recipe with exactly **two mechanical substitutions
 
 | Subclassing `Mock` | Composing a `Mock` |
 |---|---|
-| `super.load` | `mock.load` |
+| `super.load` | `self.mock.load` |
 | `adapt(...)` / `adaptThrowing(...)` (instance method) | `Mock.adapt(...)` / `Mock.adaptThrowing(...)` (static) |
 
 **The `Mock.` prefix is required, and it is the one thing that catches people out.** `adapt` is an instance method on `Mock`; a composing type does not inherit it. Use the static overloads — they take the spy as their first argument and behave identically. (A file-scope `func adapt` shadow also works, but the static form is clearer.)
+
+**Spell it `self.mock.load`, not `mock.load`.** A bare `mock` works in a plain method body, but settable members read the spy inside an escaping closure, where Swift demands explicit `self`:
+
+```
+error: reference to property 'mock' in closure requires explicit use of 'self' to make capture semantics explicit
+```
+
+`super` never needed the qualifier, so this has no inheritance counterpart. Using `self.` everywhere is the simplest rule and matches what `[.composition]` generates. Static members are the exception — they read a static property, which needs no qualifier.
 
 Everything else is unchanged: the two-member rule, the effect→adapter table, the explicit `()` for zero-arg members, `Interaction` generic ordering, settable properties' two-spy structure, subscript spy naming.
 
@@ -215,7 +283,7 @@ Composition also gives one thing raw spies don't: a **single `clear()`** across 
 - **No `super` calls to real behavior after stubbing** — an override forwards to the spy or to `super`, not both. Partial mocks aren't supported; branch inside the override if you need one.
 - **Non-overridable storage**: a stored `var` on the base class can't be turned into a spy-backed property in a subclass. Override a computed property, or compose.
 - **Class initializers** must still satisfy the superclass — call a real `super.init(...)`; `Mock`'s empty-init convention doesn't apply.
-- **Composition doesn't inherit `Mock`'s conveniences**: `clear()`, `adapt`, and `DefaultProvider` conformance are all on `Mock`. Forward them explicitly if needed.
+- **Composition doesn't inherit `Mock`'s conveniences**: `clear()`, `adapt`, and `DefaultProvider` conformance are all on `Mock`. Forward them explicitly if needed. `verifyZeroInteractions` is the exception — it takes a `MockProviding`, so it accepts a composed mock directly. Conform to `MockProviding` (a `var mock: Mock { get }`) to get that; `[.composition]` output already does, and any type with a `let mock = Mock()` satisfies it for free.
 
 ## Sanity check
 


### PR DESCRIPTION
## Problem

A protocol carrying a **class constraint** cannot be mocked at all today:

```swift
@Mockable
protocol ViewControllerService: SampleBase {
    func modified() -> Data
}
```

```
error: type 'MockViewControllerService' does not conform to protocol 'ViewControllerService'
error: 'ViewControllerService' requires that 'MockViewControllerService' inherit from 'SampleBase'
```

The mock must inherit `SampleBase` to conform and `Mock` to function, and Swift permits one superclass. This is a class constraint, not protocol inheritance — and unlike that case (where marking the parent `@Mockable` is a workaround), **no hand-edit rescues the generated output**.

## Fix

`@Mockable([.composition])` generates a mock that *holds* a `Mock` instead of inheriting one, freeing the superclass slot:

```swift
class MockViewControllerService: SampleBase, ViewControllerService, MockProviding, @unchecked Sendable {
    let mock = Mock()
    static let staticMock = Mock()          // only when the protocol has static requirements

    func modified() -> Interaction<Void, None, Data> { Interaction(.any, spy: self.mock.modified) }
    func modified() -> Data { return Mock.adapt(self.mock.modified, ()) }
}
```

Opt-in only: the macro cannot tell a class from a protocol by name, so it never infers the strategy.

### `MockProviding`

`verifyZeroInteractions` took a concrete `Mock`, so it could not accept a composed mock. It now takes `some MockProviding` (`var mock: Mock { get }`). `Mock` conforms returning `self`, so **one overload serves both strategies** and every existing call site is source-compatible — verified for concrete subclasses, base-`Mock` bindings, and existentials.

### Implementation

A `SpyAccess` value carries the strategy (spy base expression + adapter callee) through the builders, defaulting to `.inherited`. Default-strategy expansions are byte-identical — confirmed by zero snapshot churn.

## Findings worth review

Each verified against the compiler:

- **`Void` returns need `return`.** Under composition, `Mock.adapt(mock.ping, ())` in a `Void` body cannot infer `Output` and reports a misleading `failed to produce diagnostic for expression; please submit a bug report`. `functionRequirementBody` already emits `return`, so no new workaround was needed — but the constraint is now documented where it's load-bearing.
- **`self.mock` is required, not stylistic.** Settable members read the spy inside an escaping closure, where Swift demands explicit `self`. Caught only by compiling generated output.
- **Statics work** via separate `staticMock` storage — a static member can't reach an instance property. Emitted only when needed, using the previously-unused `hasStaticMembers`.
- **Initializer requirements needed a fix** (see below).
- **Naming bug fixed en route:** `processProtocol`'s fallback assumed *suffix* while `.default` is *prefix*, so `@Mockable([.composition])` alone would have silently renamed `MockService` → `ServiceMock`. Now derived from `.default`.

## Initializer requirements

Found by parametrizing the existing protocol shapes over the new strategy. A composed mock inherits its required superclass, so its initializer must chain to `super.init`; the generated body was empty:

```
error: 'super.init' isn't called on all paths before returning from initializer
```

The macro cannot synthesize that call — it never sees the superclass. Emitting `super.init()` is not a fix either: it fails identically whenever the superclass has no zero-argument initializer. The body is now `fatalError(...)`, which satisfies the chaining rule without naming an initializer and costs nothing, since the generated `init` exists only to satisfy the requirement.

The inheriting strategy is unchanged — `Mock` always has a zero-argument initializer, so the empty body compiles.

The bug was masked whenever the required superclass happened to have a zero-argument init, which is why the first round of composition tests missed it.

## Tests

- `CompositionStrategyTests` (7 tests) — the motivating class-constrained protocol end to end: methods, `Void` returns, getters, settable properties, statics, `verifyZeroInteractions`, superclass identity.
- `CompositionShapeMatrixTests` (8 tests, new) — one class-constrained protocol per generation-relevant shape: async throws, variadic, generic method, subscript, settable multi-index subscript, escaping closure, static, initializer. Largely a **compile-time** assertion: the composed strategy rewrites every spy reference and adapter call, and snapshot tests cannot catch output that is well-formed text yet fails to build. Each still round-trips so the wiring is proven connected, not merely valid.
- `MacroOptionsTests` — 3 snapshot tests: composed shape, static-storage variant, initializer body.

| Suite | Result |
|---|---|
| `swift test` | **247** passed (was 229 on main) |
| `Swift5CompatTests` | 3 passed |
| `Examples/` | 19 passed |

One note: the settable multi-index subscript test needs an explicit type annotation on the write interaction. That's a pre-existing pack-inference limitation already documented in `SubscriptInteractionTests`, not specific to `.composition`.

## Skill docs

`skills/swift-mocking/` updated: routing for class-constrained protocols, a macro-generated composition section (output taken from the CLI, not written by hand), the `self.mock` correction to the hand-written recipe, and the `verifyZeroInteractions` change.

`references/interface/SwiftMocking.swiftinterface` was regenerated via `Scripts/generate-interface.sh`. Note it also picked up unrelated staleness (`neverCalled`, `UntilError`, `SourceLocation` from earlier commits) — the file simply hadn't been regenerated since. Happy to split that into its own commit if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a composition strategy for generating mocks without inheriting from `Mock`.
  - Added support for class-constrained protocols, static members, and composed mock verification.
  - Added `MockProviding` to access mock interaction storage consistently.
  - Improved generated spy references for static and instance members.

- **Documentation**
  - Added guidance for composition-based mocking, supported protocol shapes, CLI usage, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->