### PR TITLE
Support macro options in the `mockable` CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ swift build -c release --product mockable   # → .build/release/mockable
 echo 'protocol PricingService { func price(_ item: String) throws -> Int }' | .build/release/mockable
 ```
 
+The input needs no annotation — a bare protocol is mocked as-is. Pass `--options` to choose a generation strategy for protocols you cannot annotate, such as one vended by a library you don't own:
+
+```bash
+# A class-constrained protocol needs `.composition`; the default inheriting
+# strategy cannot mock it, since Mock would claim the one superclass slot.
+echo 'protocol Service: UIViewController { func load() }' | mockable --options composition
+```
+
+`--options` takes a comma-separated list (`--options composition,suffixMock`) and accepts the same names as the macro's attribute. It supplies the default only: a protocol carrying an explicit `@Mockable([...])` keeps the options written there.
+
 ---
 
 ## 🚀 Example

--- a/Sources/MockableCLI/main.swift
+++ b/Sources/MockableCLI/main.swift
@@ -1,32 +1,47 @@
 import Foundation
 
 import MockableGenerator
+import SwiftMockingOptions
 
 let usage = """
-usage: mockable
+usage: mockable [--options <list>] [--no-debug-wrap]
 
 Build once with: swift build -c release --product mockable
 Binary: .build/release/mockable
 
 Reads Swift source from stdin and writes a mock class for every top-level
 protocol declaration to stdout. Output is byte-identical to what the
-`@Mockable` macro expands to, including the `#if DEBUG` wrapper.
+`@Mockable` macro expands to, including the `#if DEBUG` wrapper. The input
+does not need to be annotated — a bare protocol is mocked as-is.
 
-Generation options are read from a `@Mockable` attribute on each protocol,
-when present (e.g. `@Mockable([.suffixMock])`). Protocols without the
-attribute use the default options.
+--options <list>  Comma-separated generation options applied to protocols
+                  that carry no `@Mockable` attribute of their own, so
+                  protocols you cannot annotate (a third-party library's,
+                  say) still reach every generation strategy. Recognized:
+                  \(MockableOptions.allIdentifiers.joined(separator: ", ")).
+                  Leading dots are accepted, so both `composition` and
+                  `.composition` work. Defaults to \(MockableOptions.default.identifiers.joined(separator: ", ")).
 
-By default output keeps the `#if DEBUG` wrapper the macro emits. Pass
---no-debug-wrap to emit the mock class bare — the right choice when pasting
-into a test target, since DEBUG is defined per build configuration (not per
-target) and a wrapped mock vanishes under `swift test -c release`.
+                  A protocol that *does* carry `@Mockable([...])` keeps the
+                  options written there; this flag never overrides them.
 
-Example:
+                  Use `.composition` for a protocol with a class constraint
+                  (`protocol Service: UIViewController`), which cannot be
+                  mocked by the default inheriting strategy.
+
+--no-debug-wrap   Emit the mock class bare, without the `#if DEBUG` wrapper
+                  the macro emits — the right choice when pasting into a test
+                  target, since DEBUG is defined per build configuration (not
+                  per target) and a wrapped mock vanishes under
+                  `swift test -c release`.
+
+Examples:
   echo 'protocol PricingService { func price(_ item: String) -> Int }' | mockable
+  echo 'protocol Service: SomeBase { func load() }' | mockable --options composition
 
 Exit status:
   0  success
-  1  input is not valid Swift or declares no protocol
+  1  input is not valid Swift, declares no protocol, or arguments are invalid
 
 Warnings (e.g. a protocol that inherits another protocol, whose inherited
 requirements the generator does not implement) are written to stderr; stdout
@@ -56,28 +71,72 @@ func printWarnings(for mocks: [GeneratedMock]) {
     }
 }
 
-func run(includeDebugWrapper: Bool) throws {
+func run(includeDebugWrapper: Bool, defaultOptions: MockableOptions) throws {
     let mocks = try MockableGenerator.generateMocks(
         source: readStdin(),
-        includeDebugWrapper: includeDebugWrapper
+        includeDebugWrapper: includeDebugWrapper,
+        defaultOptions: defaultOptions
     )
     printWarnings(for: mocks)
     print(mocks.map(\.source).joined(separator: "\n\n"))
 }
 
-let supportedArguments: Set<String> = ["--no-debug-wrap"]
+/// Fails with the given message and the usage text, as a bad invocation is a
+/// usage error rather than a generation failure.
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("error: \(message)\n\n\(usage)\n".utf8))
+    exit(1)
+}
+
+struct Arguments {
+    var includeDebugWrapper = true
+    var defaultOptions = MockableOptions.default
+    var showHelp = false
+}
+
+func parseArguments(_ arguments: [String]) -> Arguments {
+    var parsed = Arguments()
+    var index = arguments.startIndex
+
+    while index < arguments.endIndex {
+        let argument = arguments[index]
+        switch argument {
+        case "-h", "--help":
+            parsed.showHelp = true
+        case "--no-debug-wrap":
+            parsed.includeDebugWrapper = false
+        case "--options":
+            index += 1
+            guard index < arguments.endIndex else {
+                fail("'--options' requires a value, e.g. --options composition")
+            }
+            let value = arguments[index]
+            // The generator's own parser, so the CLI accepts exactly what the
+            // macro's attribute does — including a bracketed, dotted list.
+            guard let options = MockableOptions(stringLiteral: value) else {
+                fail(
+                    "unrecognized option in '--options \(value)' " +
+                    "(recognized: \(MockableOptions.allIdentifiers.joined(separator: ", ")))"
+                )
+            }
+            parsed.defaultOptions = options
+        default:
+            fail("unsupported argument '\(argument)'")
+        }
+        index += 1
+    }
+    return parsed
+}
 
 do {
-    let arguments = Array(CommandLine.arguments.dropFirst())
-    if arguments.contains(where: { $0 == "-h" || $0 == "--help" }) {
+    let arguments = parseArguments(Array(CommandLine.arguments.dropFirst()))
+    if arguments.showHelp {
         print(usage)
-    } else if let unsupported = arguments.first(where: { !supportedArguments.contains($0) }) {
-        FileHandle.standardError.write(
-            Data("error: unsupported argument '\(unsupported)'\n\n\(usage)\n".utf8)
-        )
-        exit(1)
     } else {
-        try run(includeDebugWrapper: !arguments.contains("--no-debug-wrap"))
+        try run(
+            includeDebugWrapper: arguments.includeDebugWrapper,
+            defaultOptions: arguments.defaultOptions
+        )
     }
 } catch {
     FileHandle.standardError.write(Data("error: \(error)\n".utf8))

--- a/Sources/MockableGenerator/MockableGenerator+Source.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Source.swift
@@ -56,9 +56,13 @@ public extension MockableGenerator {
     /// generated here are byte-identical to their macro-generated counterparts.
     ///
     /// Options are read from a `@Mockable` attribute on each protocol, when
-    /// present. A protocol without the attribute uses the default options.
+    /// present. A protocol without the attribute uses `defaultOptions`.
     /// - Parameter source: Swift source text containing at least one top-level
     ///   protocol declaration.
+    /// - Parameter defaultOptions: Options applied to protocols that declare
+    ///   none of their own, letting callers mock protocols they cannot annotate
+    ///   — the CLI's `--options` flag. An explicit `@Mockable([...])` on a
+    ///   protocol takes precedence over this.
     /// - Parameter includeDebugWrapper: When `true` (the default) output keeps
     ///   the `#if DEBUG` wrapper the macro emits. Pass `false` to emit the mock
     ///   class bare — appropriate for mocks pasted into test targets, which
@@ -66,7 +70,11 @@ public extension MockableGenerator {
     ///   configuration, not per target, so a bare mock also survives
     ///   `swift test -c release`).
     /// - Returns: One `GeneratedMock` per protocol, in declaration order.
-    static func generateMocks(source: String, includeDebugWrapper: Bool = true) throws -> [GeneratedMock] {
+    static func generateMocks(
+        source: String,
+        includeDebugWrapper: Bool = true,
+        defaultOptions: MockableOptions = .default
+    ) throws -> [GeneratedMock] {
         let sourceFile = Parser.parse(source: source)
 
         let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: sourceFile)
@@ -81,7 +89,7 @@ public extension MockableGenerator {
             throw MockableGeneratorError.noProtocolsFound
         }
         return try protocolDecls.map { protocolDecl in
-            let mockSource = try processProtocol(protocolDecl: protocolDecl)
+            let mockSource = try processProtocol(protocolDecl: protocolDecl, defaultOptions: defaultOptions)
                 .flatMap { decl -> [DeclSyntax] in
                     guard !includeDebugWrapper, let ifConfig = decl.as(IfConfigDeclSyntax.self) else {
                         return [decl]

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -25,9 +25,16 @@ public enum MockableGenerator {
     ///     }
     /// }
     /// ```
-    public static func processProtocol(protocolDecl: ProtocolDeclSyntax) throws -> [DeclSyntax] {
+    /// - Parameter defaultOptions: Options applied to a protocol that declares
+    ///   none of its own. Defaults to ``MockableOptions/default``; the
+    ///   `mockable` CLI passes its `--options` flag here, so an explicit
+    ///   `@Mockable([...])` in the source still wins.
+    public static func processProtocol(
+        protocolDecl: ProtocolDeclSyntax,
+        defaultOptions: MockableOptions = .default
+    ) throws -> [DeclSyntax] {
         let protocolName = protocolDecl.name.text
-        let codeGenOptions = MockableGenerator.codeGenOptions(protocolDecl: protocolDecl)
+        let codeGenOptions = declaredCodeGenOptions(protocolDecl: protocolDecl) ?? defaultOptions
         let mockName: String
         if codeGenOptions.contains(.prefixMock) {
             mockName = "Mock" + protocolName
@@ -36,7 +43,8 @@ public enum MockableGenerator {
         } else {
             // No naming option given — follow `.default` rather than assuming a
             // suffix, so an options list that names only non-naming options
-            // (`[.composition]`) keeps the same name as a bare `@Mockable`.
+            // (`[.composition]`, or `--options composition`) keeps the same name
+            // as a bare `@Mockable`.
             mockName = MockableOptions.default.contains(.prefixMock)
                 ? "Mock" + protocolName
                 : protocolName + "Mock"
@@ -222,6 +230,21 @@ public enum MockableGenerator {
     /// ```
     /// This function will return `[.prefixMock]`.
     public static func codeGenOptions(protocolDecl: ProtocolDeclSyntax) -> MockableOptions {
+        declaredCodeGenOptions(protocolDecl: protocolDecl) ?? .default
+    }
+
+    /// Extracts mock generation options written on a protocol, distinguishing
+    /// "no options were written" from "options were written and they happen to
+    /// match the defaults".
+    ///
+    /// Callers that need to supply their own fallback — the `mockable` CLI,
+    /// whose `--options` flag applies only to protocols that carry no options
+    /// of their own — use this instead of ``codeGenOptions(protocolDecl:)``.
+    ///
+    /// Returns `nil` when the protocol has no attribute bearing a recognized
+    /// options list, so a bare `protocol Foo {}` and a `@Mockable` with no
+    /// arguments both defer to the caller's default.
+    public static func declaredCodeGenOptions(protocolDecl: ProtocolDeclSyntax) -> MockableOptions? {
         for attribute in protocolDecl.attributes {
             // Skip attributes that aren't option-bearing calls rather than
             // bailing out: a protocol may carry `@available(...)` or a doc
@@ -237,7 +260,7 @@ public enum MockableGenerator {
                 return parsedOption
             }
         }
-        return .default
+        return nil
     }
 
     /// Extracts all associated type declarations from a protocol.

--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -223,13 +223,12 @@ public enum MockableGenerator {
     /// This function will return `[.prefixMock]`.
     public static func codeGenOptions(protocolDecl: ProtocolDeclSyntax) -> MockableOptions {
         for attribute in protocolDecl.attributes {
-            guard let attr = attribute.as(AttributeSyntax.self) else {
-                return .default
-            }
-
-            guard let arguments = attr.arguments?.as(LabeledExprListSyntax.self) else {
-                // No arguments or unexpected format
-                return .default
+            // Skip attributes that aren't option-bearing calls rather than
+            // bailing out: a protocol may carry `@available(...)` or a doc
+            // attribute alongside `@Mockable([.composition])`, in any order.
+            guard let attr = attribute.as(AttributeSyntax.self),
+                  let arguments = attr.arguments?.as(LabeledExprListSyntax.self) else {
+                continue
             }
             for argument in arguments {
                 guard let parsedOption = MockableOptions(stringLiteral: argument.expression.description) else {

--- a/Sources/SwiftMockingOptions/MockableOptions.swift
+++ b/Sources/SwiftMockingOptions/MockableOptions.swift
@@ -95,6 +95,13 @@ public struct MockableOptions: OptionSet, Sendable {
         self = combinedOptions
     }
 
+    /// Every option name accepted by ``init(stringLiteral:)``, in declaration order.
+    ///
+    /// Lets callers that surface the option list to users — the `mockable`
+    /// CLI's `--help` and its error message for an unrecognized option — stay
+    /// in step with the parser as options are added.
+    public static let allIdentifiers: [String] = ["prefixMock", "suffixMock", "composition"]
+
     /// Returns an array of string identifiers for the options currently set.
     public var identifiers: [String] {
         var names: [String] = []

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -161,24 +161,81 @@ final class GeneratorPipelineTests: XCTestCase {
         }
     }
 
-    func testCodeGenOptionsReadsMockableAttributeAlongsideOtherAttributes() throws {
-        // A non-option attribute preceding `@Mockable` must not abort the scan.
-        let protocolDecl = try XCTUnwrap(
-            Parser.parse(
-                source: """
-                @available(*, deprecated)
-                @Mockable([.suffixMock])
-                protocol Service {
-                    func load()
-                }
-                """
-            )
-            .statements.first?.item.as(ProtocolDeclSyntax.self)
+    func testGenerateMocksAppliesDefaultOptionsToProtocolWithoutAttribute() throws {
+        // The CLI's `--options` case: mocking a protocol you cannot annotate,
+        // such as one vended by a third-party library.
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            protocol Service: SomeBase {
+                func load()
+            }
+            """,
+            includeDebugWrapper: false,
+            defaultOptions: [.composition]
         )
 
+        let source = try XCTUnwrap(mocks.first?.source)
+        XCTAssertTrue(
+            source.contains("class MockService: SomeBase, Service, MockProviding, @unchecked Sendable {"),
+            "composition should compose rather than inherit Mock: \(source)"
+        )
+        XCTAssertTrue(source.contains("let mock = Mock()"), source)
+    }
+
+    func testGenerateMocksPrefersAttributeOptionsOverDefaultOptions() throws {
+        // An explicit attribute wins; the fallback only fills in for protocols
+        // that declare nothing of their own.
+        let mocks = try MockableGenerator.generateMocks(
+            source: """
+            @Mockable([.suffixMock])
+            protocol Annotated {
+                func a()
+            }
+
+            protocol Bare {
+                func b()
+            }
+            """,
+            includeDebugWrapper: false,
+            defaultOptions: [.composition]
+        )
+
+        XCTAssertEqual(mocks.map(\.protocolName), ["Annotated", "Bare"])
+        XCTAssertTrue(
+            mocks[0].source.contains("class AnnotatedMock: Mock, @unchecked Sendable, Annotated {"),
+            "attribute options should survive a conflicting fallback: \(mocks[0].source)"
+        )
+        XCTAssertTrue(
+            mocks[1].source.contains("class MockBare: Bare , MockProviding, @unchecked Sendable {"),
+            "unannotated protocol should take the fallback: \(mocks[1].source)"
+        )
+    }
+
+    func testGenerateMocksWithNonNamingDefaultOptionsKeepsDefaultPrefixName() throws {
+        // `.composition` names no naming strategy, so the name must still come
+        // from `.default` (prefix) rather than falling through to a suffix.
+        let mocks = try MockableGenerator.generateMocks(
+            source: "protocol Service { func load() }",
+            includeDebugWrapper: false,
+            defaultOptions: [.composition]
+        )
+
+        XCTAssertTrue(mocks[0].source.contains("class MockService:"), mocks[0].source)
+    }
+
+    func testDeclaredCodeGenOptionsIsNilWhenProtocolDeclaresNoOptions() throws {
+        func declaredOptions(_ source: String) throws -> MockableOptions? {
+            let protocolDecl = try XCTUnwrap(
+                Parser.parse(source: source).statements.first?.item.as(ProtocolDeclSyntax.self)
+            )
+            return MockableGenerator.declaredCodeGenOptions(protocolDecl: protocolDecl)
+        }
+
+        XCTAssertNil(try declaredOptions("protocol Bare { func a() }"))
+        XCTAssertNil(try declaredOptions("@Mockable\nprotocol NoArguments { func a() }"))
         XCTAssertEqual(
-            MockableGenerator.codeGenOptions(protocolDecl: protocolDecl),
-            [.suffixMock]
+            try declaredOptions("@Mockable([.composition])\nprotocol Annotated { func a() }"),
+            [.composition]
         )
     }
 

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -1,6 +1,9 @@
+import SwiftParser
+import SwiftSyntax
 import XCTest
 
 import MockableGenerator
+import SwiftMockingOptions
 
 /// Tests that `MockableGenerator.generateMocks(source:)` — the pipeline behind the
 /// `mockable` CLI — produces output byte-identical to the fixtures pinned by the
@@ -156,6 +159,27 @@ final class GeneratorPipelineTests: XCTestCase {
             }
             XCTAssertTrue(diagnostics.contains("error:"), "diagnostics should annotate errors: \(diagnostics)")
         }
+    }
+
+    func testCodeGenOptionsReadsMockableAttributeAlongsideOtherAttributes() throws {
+        // A non-option attribute preceding `@Mockable` must not abort the scan.
+        let protocolDecl = try XCTUnwrap(
+            Parser.parse(
+                source: """
+                @available(*, deprecated)
+                @Mockable([.suffixMock])
+                protocol Service {
+                    func load()
+                }
+                """
+            )
+            .statements.first?.item.as(ProtocolDeclSyntax.self)
+        )
+
+        XCTAssertEqual(
+            MockableGenerator.codeGenOptions(protocolDecl: protocolDecl),
+            [.suffixMock]
+        )
     }
 
     func testGenerateMocksWithoutDebugWrapperOmitsIfConfigAndKeepsMembers() throws {

--- a/skills/swift-mocking/SKILL.md
+++ b/skills/swift-mocking/SKILL.md
@@ -61,7 +61,12 @@ echo 'protocol P { func price(_ item: String) throws -> Int }' | mockable
 
 Invoke as `mockable` when it is on `PATH`; otherwise `.build/release/mockable` inside a swift-mocking checkout (build once with `swift build -c release --product mockable`, then optionally copy the binary onto `PATH`).
 
-- Options ride the input: `@Mockable([.suffixMock]) protocol P {...}` on stdin. `[.composition]` works here too — the fastest way to see the composed shape for a given protocol.
+- Input needs no annotation — paste the protocol as it is written in the source you're mocking.
+- Pass options with `--options`, comma-separated (`--options composition,suffixMock`). Use it for protocols you can't or shouldn't annotate — most importantly `--options composition` for a protocol constrained to a class, the fastest way to see the composed shape:
+  ```bash
+  echo 'protocol P: UIViewController { func load() }' | mockable --options composition
+  ```
+- Options may still ride the input as `@Mockable([.suffixMock]) protocol P {...}`, which wins over `--options`. Prefer the flag: it keeps the stdin text identical to the real declaration.
 - Default output keeps the macro's `#if DEBUG` wrapper; pass `--no-debug-wrap` when pasting into a test target (DEBUG is per build configuration — a wrapped mock vanishes under `swift test -c release`).
 - A stderr warning about inherited requirements means the output will not conform — hand-write per manual-mocking.md instead.
 - Output keeps the macro's zero-arg/property-getter shape: `when(...)` silently stubs a disconnected spy, and `verify(...)` reports zero calls for those members — apply the pinned-spy fix from manual-mocking.md before relying on them.


### PR DESCRIPTION
## Motivation

The CLI reads generation options from a `@Mockable` attribute on its input, which meant non-default strategies were reachable *only* by annotating the source. That defeats the tool's purpose: it exists to generate mocks as source for protocols you don't own — exactly the ones you can't annotate.

The practical consequence: a class-constrained protocol (`protocol Service: UIViewController`) requires `.composition`, since the default strategy needs `Mock` in the superclass slot. Through the CLI, that was unreachable without hand-editing an attribute onto a copy of the declaration first.

Note that mocking a **bare, unannotated protocol already worked** — that part needed no change. What was missing was any way to choose *how* it gets generated.

## What changed

```bash
echo 'protocol Service: UIViewController { func load() }' | mockable --options composition
```

`--options` takes the same comma-separated names the attribute does (leading dots optional), reusing `MockableOptions(stringLiteral:)` so the CLI accepts exactly what the macro accepts.

**Precedence is attribute-wins.** The flag supplies a default for protocols declaring no options; it never overrides an explicit `@Mockable([...])`. Mixed input behaves accordingly:

```
@Mockable([.suffixMock]) protocol A {}    →  AMock      (attribute)
                         protocol B {}    →  MockB: ... (flag)
```

## Two bugs fixed along the way

1. **`codeGenOptions` aborted its scan on the first non-option attribute** (`05a49ab`). `@available(*, deprecated) @Mockable([.suffixMock])` silently generated with defaults. This one is independent of the CLI work and affects the macro too.
2. **Naming fallback** stays on `.default` rather than following `defaultOptions`, so `--options composition` — which names no naming strategy — still yields `MockService`, not `ServiceMock`.

## Commits

Split so each builds and tests independently (verified):

- `05a49ab` — read `@Mockable` options past other attributes
- `a018a7d` — `defaultOptions` plumbing through `processProtocol` / `generateMocks`
- `41f46d4` — the `--options` flag, `allIdentifiers`, README

## Testing

254 XCTest + 10 swift-testing passing, including the macro-expansion snapshots that share this generator (the macro path is untouched: `defaultOptions` is defaulted). New coverage for the fallback, attribute precedence, the non-naming-option case, and the attribute-scan fix.

Exit codes checked against the built binary: unrecognized option, missing value, and unknown flag → 1; success and `--help` → 0.

`--options ""` parses to an empty set and behaves as `.default`, which matches the attribute parser's existing handling of empty components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--options` flag to the mock generation CLI for selecting generation strategies.
  * Default options now apply to unannotated protocols, while explicit protocol settings take precedence.
  * Added clearer CLI usage guidance and validation for option lists.

* **Documentation**
  * Updated the README with examples and details for using `--options`.

* **Tests**
  * Added coverage for default options, explicit option precedence, naming behavior, and protocols without configured options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->