### PR TITLE
Drop `@unchecked` from composed mocks without a class constraint

### DIFF
--- a/Sources/MockableGenerator/MockableGenerator.swift
+++ b/Sources/MockableGenerator/MockableGenerator.swift
@@ -65,6 +65,11 @@ public enum MockableGenerator {
 
         // Create the Mock struct
         let mockStruct = ClassDeclSyntax(
+            modifiers: DeclModifierListSyntax {
+                if isStrictlySendable(protocolDecl: protocolDecl, spyAccess: spyAccess) {
+                    DeclModifierSyntax(name: .keyword(.final))
+                }
+            },
             name: TokenSyntax.identifier(mockName),
             genericParameterClause: genericParameters,
             inheritanceClause: InheritanceClauseSyntax(
@@ -83,6 +88,36 @@ public enum MockableGenerator {
         return [DeclSyntax(ifConfigDecl)]
     }
 
+    /// Whether the generated mock can conform to plain `Sendable` rather than
+    /// `@unchecked Sendable`.
+    ///
+    /// Two independent compiler rules gate this, and both must hold:
+    ///
+    /// - `non-final class cannot conform to the 'Sendable' protocol`, so the
+    ///   mock must be `final`.
+    /// - `'Sendable' class cannot inherit from another class other than
+    ///   'NSObject'`, so the mock must have no superclass.
+    ///
+    /// The second rules out inheriting mocks (they subclass ``Mock``) and any
+    /// composed mock whose protocol carries a class constraint — the case
+    /// `.composition` exists for. An empty inheritance clause is a *sufficient*
+    /// condition for the composed case: with nothing to restate, no superclass
+    /// can appear.
+    ///
+    /// It is deliberately not a *necessary* one. `protocol P: SomeProtocol` and
+    /// `protocol P: AnyObject` also have no superclass, but a bare identifier in
+    /// an inheritance clause is undecidable at expansion time — the macro sees
+    /// only syntax and cannot tell `BaseService` from `SomeBaseClass`. Those
+    /// keep `@unchecked`, which costs the guarantee but never miscompiles.
+    static func isStrictlySendable(
+        protocolDecl: ProtocolDeclSyntax,
+        spyAccess: SpyAccess
+    ) -> Bool {
+        guard case .composed = spyAccess else { return false }
+        let inherited = protocolDecl.inheritanceClause?.inheritedTypes ?? []
+        return inherited.isEmpty
+    }
+
     /// Builds the generated mock's inheritance clause.
     ///
     /// Inheriting mocks are `Mock, @unchecked Sendable, <Protocol>`.
@@ -93,6 +128,12 @@ public enum MockableGenerator {
     /// conformers to inherit that class, and the slot is taken by `Mock` under
     /// the default strategy. Inherited *protocols* are harmless here: conforming
     /// to the most-derived protocol already implies them.
+    ///
+    /// A composing mock with nothing to restate conforms to plain `Sendable`
+    /// instead — see ``isStrictlySendable(protocolDecl:spyAccess:)``. Its only
+    /// storage is a `let` of `Mock`, itself `@unchecked Sendable` over
+    /// `NSLock`-guarded internals, so the conformance is checkable rather than
+    /// asserted: the compiler rejects any mutable stored property added later.
     ///
     /// `MockProviding` is added so `verifyZeroInteractions` accepts the mock;
     /// inheriting mocks get that conformance from `Mock` itself.
@@ -123,10 +164,13 @@ public enum MockableGenerator {
         case .composed:
             let inherited = protocolDecl.inheritanceClause?.inheritedTypes
                 .map { TypeSyntax(stringLiteral: $0.type.trimmedDescription) } ?? []
+            let sendable = isStrictlySendable(protocolDecl: protocolDecl, spyAccess: spyAccess)
+                ? TypeSyntax(IdentifierTypeSyntax(name: .identifier("Sendable")))
+                : uncheckedSendable
             types = inherited + [
                 TypeSyntax(IdentifierTypeSyntax(name: protocolDecl.name)),
                 TypeSyntax(IdentifierTypeSyntax(name: .identifier("MockProviding"))),
-                uncheckedSendable
+                sendable
             ]
         }
 

--- a/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
+++ b/Tests/SwiftMockingMacrosTests/GeneratorPipelineTests.swift
@@ -205,8 +205,10 @@ final class GeneratorPipelineTests: XCTestCase {
             mocks[0].source.contains("class AnnotatedMock: Mock, @unchecked Sendable, Annotated {"),
             "attribute options should survive a conflicting fallback: \(mocks[0].source)"
         )
+        // `Bare` has no inheritance clause, so the composed mock has no
+        // superclass and conforms to plain `Sendable` as a `final` class.
         XCTAssertTrue(
-            mocks[1].source.contains("class MockBare: Bare , MockProviding, @unchecked Sendable {"),
+            mocks[1].source.contains("final class MockBare: Bare , MockProviding, Sendable {"),
             "unannotated protocol should take the fallback: \(mocks[1].source)"
         )
     }

--- a/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
+++ b/Tests/SwiftMockingMacrosTests/MacroOptionsTests.swift
@@ -70,6 +70,47 @@ final class MacroOptionsTests: MacroTestCase {
         }
     }
 
+    /// A composed protocol with no inheritance clause has no superclass to
+    /// restate, so the mock can be `final` and conform to plain `Sendable`.
+    ///
+    /// Both are required together: a non-final class cannot conform to
+    /// `Sendable`, and a `Sendable` class cannot inherit another class. The
+    /// conformance is checkable rather than asserted — the mock's only storage
+    /// is `let mock`, so the compiler rejects any mutable stored property.
+    ///
+    /// Contrast ``testCompositionOption()``, where `SampleBase` occupies the
+    /// superclass slot and `@unchecked` is structurally unavoidable.
+    func testCompositionWithoutInheritanceClauseIsStrictlySendable() {
+        assertMacro {
+            """
+            @Mockable([.composition])
+            protocol MyService {
+                func doSomething()
+            }
+            """
+        } expansion: {
+            """
+            protocol MyService {
+                func doSomething()
+            }
+
+            #if DEBUG
+            final class MockMyService: MyService , MockProviding, Sendable {
+                let mock = Mock()
+
+                func doSomething() -> Interaction<Void, None, Void> {
+                    Interaction(.any, spy: self.mock.doSomething)
+                }
+
+                func doSomething() {
+                    return Mock.adapt(self.mock.doSomething, ())
+                }
+            }
+            #endif
+            """
+        }
+    }
+
     /// A protocol with static requirements gets a second `Mock` for them:
     /// static members cannot reach an instance property. It carries the mock's
     /// own type name as its scoped storage key, so those spies land in


### PR DESCRIPTION
## Summary

Composed mocks whose protocol has no inheritance clause now generate `final class ...: Sendable` instead of `class ...: @unchecked Sendable`.

```swift
// before
class MockMyService: MyService, MockProviding, @unchecked Sendable {

// after
final class MockMyService: MyService, MockProviding, Sendable {
```

An empty inheritance clause is a *sufficient* condition for this: with nothing to restate, the mock can have no superclass. That matters because two independent compiler rules gate plain `Sendable`, and both must hold:

- `non-final class cannot conform to the 'Sendable' protocol` → the mock must be `final`.
- `'Sendable' class cannot inherit from another class other than 'NSObject'` → the mock must have no superclass.

The second rules out inheriting mocks (they subclass `Mock`) and class-constrained composed mocks (`protocol MyService: SampleBase`) — the case `.composition` exists for. Those keep `@unchecked`, which is structural and unavoidable.

The conformance is checkable rather than asserted: the mock's only storage is `let mock = Mock()`, itself `@unchecked Sendable` over `NSLock`-guarded internals, so the compiler rejects any mutable stored property added later.

## Verification

- `final` alone does **not** relax the no-superclass rule — confirmed `final class ...: SampleBase, Sendable` is still rejected. The two rules are independent.
- The realistic generated shape (`let mock`, `static let` scoped storage, settable property, static requirements) typechecks clean under `-swift-version 6 -strict-concurrency=complete`.
- The guarantee bites: adding `var callCount = 0` fails with *"stored property of 'Sendable'-conforming class is mutable."*
- `required init` on a `final` class produces no warning, so the initializer path is unaffected.
- 255/255 tests pass in the main package; 19/19 in Examples (clean rebuild). The two warnings in `Examples/Tests/ExamplesTests/ExampleXCTests.swift` are pre-existing in hand-written test code and unrelated.

## Tests

- Added `testCompositionWithoutInheritanceClauseIsStrictlySendable`, pinning the new output against the existing `testCompositionOption` which pins the class-constrained case that keeps `@unchecked`.
- Updated one assertion in `GeneratorPipelineTests`: `protocol Bare` takes the `.composition` fallback and now correctly generates `final`. Expected churn, not a regression.

## Notes for review

**Source-breaking.** `final` closes off subclassing generated composed mocks, with no opt-out. This is deliberate — needing to subclass a generated mock signals a missing library feature rather than a use case to preserve — but it's a release-note item.

**Deliberately conservative.** `protocol P: SomeProtocol` and `protocol P: AnyObject` also have no superclass, but a bare identifier in an inheritance clause is undecidable at macro-expansion time — the generator sees only syntax and cannot tell `BaseService` from `SampleBase`. Those keep `@unchecked`: costs the guarantee, never miscompiles. No mocks in the repo are currently affected (the 33 composed protocols split into 23 empty-clause and 10 class-constrained), but since protocol inheritance is a documented pattern, handling `AnyObject`/marker protocols is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated mocks for protocols without inherited types are now marked `final` and use standard `Sendable` conformance.
  * Mocks involving inherited protocol types continue using `@unchecked Sendable` where needed.

* **Bug Fixes**
  * Corrected generated mock declarations and concurrency behavior for protocols without inheritance clauses.

* **Tests**
  * Added and updated coverage to verify strict `Sendable` mock generation and related adapter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->