### PR TITLE
Add `.any(where:equals:)` and steer matchers away from `.any(that:)`

### DIFF
--- a/Sources/SwiftMocking/ArgMatcher.swift
+++ b/Sources/SwiftMocking/ArgMatcher.swift
@@ -97,6 +97,13 @@ public struct ArgMatcher<Argument>: Sendable {
     /// // Stubbing a method to return a value if the integer argument is even
     /// spy.when(calledWith: .any(that: { $0 % 2 == 0 })).thenReturn("even")
     /// ```
+    ///
+    /// - Note: The predicate is `@Sendable`, and Swift's inference does not always
+    ///   propagate that through the member chain — you may see *"Converting non-Sendable
+    ///   function value to '@Sendable (T) -> Bool' may introduce data races"*. When the
+    ///   condition is just a property compared to a value, prefer
+    ///   ``any(where:equals:)``, which captures a value instead of a closure. Otherwise
+    ///   annotate the closure: `.any(that: { @Sendable in ... })`.
     public static func any(that predicate: @escaping @Sendable (Argument) -> Bool) -> Self {
         return .init(precedence: .predicate, matcher: predicate)
     }
@@ -364,19 +371,34 @@ public extension ArgMatcher {
     /// }
     ///
     /// // Stub the getUser method to return a user when the id property of the argument is "123"
-    /// when(mockUserService.getUser(user: .any(where: \.id, "123"))).thenReturn(User(id: "123", name: "Test User"))
+    /// when(mockUserService.getUser(user: .any(where: \.id, equals: "123"))).thenReturn(User(id: "123", name: "Test User"))
     ///
     /// // Verify that getUser was called with a user whose name property is "Alice"
-    /// verify(mockUserService.getUser(user: .any(where: \.name, "Alice"))).called()
+    /// verify(mockUserService.getUser(user: .any(where: \.name, equals: "Alice"))).called()
     /// ```
+    ///
+    /// Prefer this over `.any(that:)` when you're comparing a property to a value: it
+    /// captures the value rather than a caller-supplied closure, so it never produces a
+    /// "non-Sendable function value" warning under Swift 6 concurrency checking.
     ///
     /// - Parameters:
     ///   - keyPath: A `KeyPath` to the property of the `Argument` type that should be compared.
     ///   - value: The `Equatable` value to compare the property against.
     /// - Returns: An `ArgMatcher` that matches arguments where the specified property equals the given value.
-    static func any<Property: Equatable & Sendable>(where keyPath: KeyPath<Argument, Property>, _ value: Property) -> Self where Argument: Sendable {
+    static func any<Property: Equatable & Sendable>(where keyPath: KeyPath<Argument, Property>, equals value: Property) -> Self where Argument: Sendable {
         let sendableKeyPath = SendableKeyPath(keyPath: keyPath)
         return .init(precedence: .predicate) { $0[keyPath: sendableKeyPath.keyPath] == value }
+    }
+
+    /// A matcher that matches any argument where a specific property of the argument is equal to a given value.
+    ///
+    /// - Parameters:
+    ///   - keyPath: A `KeyPath` to the property of the `Argument` type that should be compared.
+    ///   - value: The `Equatable` value to compare the property against.
+    /// - Returns: An `ArgMatcher` that matches arguments where the specified property equals the given value.
+    @_disfavoredOverload
+    static func any<Property: Equatable & Sendable>(where keyPath: KeyPath<Argument, Property>, _ value: Property) -> Self where Argument: Sendable {
+        .any(where: keyPath, equals: value)
     }
 }
 

--- a/Tests/SwiftMockingTests/ArgMatcherTests.swift
+++ b/Tests/SwiftMockingTests/ArgMatcherTests.swift
@@ -81,6 +81,16 @@ final class ArgMatcherTests: XCTestCase {
         struct User {
             let id: String
         }
+        let matcher: ArgMatcher<User> = .any(where: \.id, equals: "123")
+        XCTAssertTrue(matcher(User(id: "123")))
+        XCTAssertFalse(matcher(User(id: "456")))
+    }
+
+    /// The unlabeled form predates `equals:` and stays valid.
+    func testAnyWhereMatcherUnlabeledValueRemainsSupported() {
+        struct User {
+            let id: String
+        }
         let matcher: ArgMatcher<User> = .any(where: \.id, "123")
         XCTAssertTrue(matcher(User(id: "123")))
         XCTAssertFalse(matcher(User(id: "456")))

--- a/docs/swift6-sendable.md
+++ b/docs/swift6-sendable.md
@@ -34,8 +34,9 @@ Value-based stubbing constrains its values; closure-based stubbing constrains it
 | `thenReturn(value)` | `Output: Sendable` |
 | `thenThrow(error)` | `E: Error & Sendable` |
 | `thenReturn { ... }` / `.do { ... }` | closure is `@Sendable`, so **captures** must be Sendable |
-| Value-capturing matchers (`.equal`, `.identical`, `.contains`, `.in`, `.approximately`) | argument type `: Sendable` |
-| `.any`, `.any(that:)` | unconstrained; predicates may *take* non-Sendable values |
+| Value-capturing matchers (`.equal`, `.identical`, `.contains`, `.in`, `.approximately`, `.any(where:equals:)`) | argument type `: Sendable` |
+| `.any` | unconstrained |
+| `.any(that:)` | predicate may *take* a non-Sendable value, but its **captures** must be Sendable |
 | Default values for unstubbed returns | unconstrained |
 
 ## Working with non-Sendable types
@@ -53,11 +54,18 @@ when(mock.send(.any)).thenReturn { _ in Receipt(code: 42) }
 when(mock.validate(.any)).thenReturn { _ in throw ValidationError(reason: "invalid") }
 ```
 
-To match a non-Sendable argument, capture a Sendable stand-in instead of the instance:
+To match a non-Sendable argument, capture a Sendable stand-in instead of the instance. Prefer the key-path matcher, which captures a value rather than a closure:
 
 ```swift
 let targetID = target.id                      // UUID is Sendable
-when(mock.send(.any(that: { $0.id == targetID }))).thenReturn { _ in Receipt(code: 0) }
+when(mock.send(.any(where: \.id, equals: targetID))).thenReturn { _ in Receipt(code: 0) }
+```
+
+Use `.any(that:)` for conditions a property comparison can't express, and annotate the closure so inference can't drop `@Sendable`:
+
+```swift
+when(mock.send(.any(that: { @Sendable in $0.id == targetID && $0.retries > 3 })))
+    .thenReturn { _ in Receipt(code: 0) }
 ```
 
 **One boundary to know:** the handler overloads for `throws`, `async`, and `async throws` spies are declared `where repeat each I: Sendable`, because they defer the invocation, so the *arguments* must be Sendable too. The handler workarounds above therefore apply as written only to synchronous, non-throwing requirements. If a requirement both `throws` (or is `async`) **and** takes a non-Sendable parameter, no handler form compiles; make the parameter type `Sendable`, or restructure the requirement to take a Sendable stand-in (an ID) instead of the object.
@@ -74,7 +82,7 @@ If you are upgrading from a pre-Sendable version:
 
 1. Handler closures capturing non-Sendable state no longer compile in Swift 6 mode. Construct values inside the handler, or wrap shared state in a lock or actor.
 2. `thenReturn(value)`/`thenThrow` on non-Sendable types: switch to the handler form above.
-3. `.any(that: { ... })` may need an explicit `@Sendable` in some positions, since inference does not always propagate through the member chain.
+3. *"Converting non-Sendable function value to `@Sendable (T) -> Bool` may introduce data races"* on `.any(that:)`: inference does not always propagate `@Sendable` through the member chain. Rewrite as `.any(where: \.prop, equals: value)` when the predicate is a property comparison; otherwise annotate the closure — `.any(that: { @Sendable in ... })`.
 4. `Recorded` is no longer `Sendable` (its `arguments: [Any]` payload cannot soundly claim transfer); consume `InvocationRecorder.snapshot()` within a single isolation domain.
 
 ---

--- a/skills/swift-mocking/sendable.md
+++ b/skills/swift-mocking/sendable.md
@@ -28,7 +28,8 @@ Every closure the library stores and later invokes (possibly across isolation do
 | `thenThrow(error)` | `E: Error & Sendable` | All modes |
 | `thenReturn { args in ... }` (handler) | closure is `@Sendable` — **captures** must be Sendable | Caller's module: Swift 6 = error, Swift 5 = warning |
 | `.do { ... }` (side-effect handler) | same | same |
-| Value-capturing matchers (`.equal`, `.identical`, `.contains`, `.in`, `.approximately`, key-path `any(where:)`) | argument type `: Sendable` | All modes |
+| Value-capturing matchers (`.equal`, `.identical`, `.contains`, `.in`, `.approximately`, key-path `any(where:equals:)`) | argument type `: Sendable` | All modes |
+| `.any(that: { ... })` | closure is `@Sendable` — **captures** must be Sendable | Caller's module: Swift 6 = error, Swift 5 = warning |
 | Deferred handler overloads for async/throwing spies where **arguments** are non-Sendable | `each I: Sendable` | All modes |
 | Default-value fallback for unstubbed returns | unconstrained (values stored directly, no closure capture) | — |
 | Sync, non-throwing handler stubbing with non-Sendable args | works (runs inline) | — |
@@ -54,10 +55,17 @@ only for **synchronous, non-throwing** requirements. A requirement that both thr
 (or is async) *and* takes a non-Sendable parameter has no working handler form —
 make the parameter `Sendable`, or have it take an ID instead of the object.
 
-**Match a non-Sendable argument**: `.any` and `.any(that:)` are fine — the predicate may *take* non-Sendable params; only its *captures* must be Sendable. Compare identity by capturing a Sendable stand-in:
+**Match a non-Sendable argument**: `.any`, `.any(where:equals:)`, and `.any(that:)` are all fine — the matcher may *take* a non-Sendable argument; only what it *captures* must be Sendable. Prefer the key-path form, which captures a value rather than a closure:
 ```swift
 let targetID = target.id  // UUID is Sendable
-when(mock.send(.any(that: { $0.id == targetID }))).thenReturn { _ in ... }
+when(mock.send(.any(where: \.id, equals: targetID))).thenReturn { _ in ... }
+```
+
+Fall back to `.any(that:)` only when the condition isn't a property-equals-value
+comparison, and annotate the closure so inference can't drop `@Sendable`:
+```swift
+when(mock.send(.any(that: { @Sendable in $0.id == targetID && $0.retries > 3 })))
+    .thenReturn { _ in ... }
 ```
 
 **Default values for non-Sendable returns**: register a provider; still unconstrained. (The built-in registry and the `.withDefaults` trait are in usage.md — *Default values*; note `DefaultProviding.valueProvider` requires `Sendable`, so a non-Sendable type must use the `DefaultProviding(_:create:)` initializer as below.)
@@ -71,7 +79,7 @@ mock.defaultProviderRegistry = registry
 
 1. Handler closures capturing non-Sendable state no longer compile in Swift 6 mode. Wrap shared state in a locked box or actor, or construct values inside the handler.
 2. `thenReturn(value)`/`thenThrow` on non-Sendable types: switch to handler form (above).
-3. `.any(that: { ... })` may need an explicit `@Sendable` in some positions — inference doesn't always propagate through the member chain.
+3. *"Converting non-Sendable function value to `@Sendable (T) -> Bool` may introduce data races"* on `.any(that:)`: inference doesn't always propagate `@Sendable` through the member chain. Rewrite as `.any(where: \.prop, equals: value)` when the predicate is a property comparison; otherwise annotate the closure — `.any(that: { @Sendable in ... })`.
 4. Hand-written mocks predating `#94`: add `@unchecked Sendable` back to the inheritance clause or Swift 6 warns about the redundant/missing restatement.
 
 ## Thread-safety in tests

--- a/skills/swift-mocking/usage.md
+++ b/skills/swift-mocking/usage.md
@@ -70,9 +70,32 @@ mock.defaultProviderRegistry = registry
 | `.lessThan`, `.greaterThan`, `.lessThanOrEqual`, `.greaterThanOrEqual` | numeric comparisons |
 | `.identical(obj)` | object identity |
 | `.approximately(x, accuracy:)` | floating point |
-| `.any(where: \.name, "Ada")` | key-path projection |
+| `.any(where: \.name, equals: "Ada")` | key-path projection |
+| `.any(that: { $0.count > 3 })` | arbitrary predicate — last resort, see below |
 
 Plain values coerce: `when(mock.log("hi"))` ≡ `.equal("hi")`.
+
+**Reach for `.any(where:equals:)` before `.any(that:)`.** `.any(that:)` takes a
+`@Sendable` closure, and Swift's inference doesn't always propagate `@Sendable` through
+the member chain — a bare `.any(that: { $0.id == x })` can produce *"Converting
+non-Sendable function value to '@Sendable (T) -> Bool' may introduce data races"*. The
+key-path form captures a value instead of a closure, so it never can:
+
+```swift
+when(mock.getUser(.any(where: \.id, equals: "123"))).thenReturn(user)   // ✅ preferred
+when(mock.getUser(.any(that: { $0.id == "123" }))).thenReturn(user)     // ⚠️ may warn
+```
+
+Use `.any(that:)` only for logic a key-path comparison can't express (ranges over a
+projection, multi-field conditions, negation). When you do, annotate the closure
+explicitly to silence the warning:
+
+```swift
+when(mock.process(.any(that: { @Sendable in $0.retries > 3 && $0.isStale }))).thenReturn(true)
+```
+
+`.any(where:)` also accepts the value unlabeled (`.any(where: \.id, "123")`) for
+backward compatibility; prefer the `equals:` label in new code.
 
 ## Stubbing
 


### PR DESCRIPTION
## Problem

`.any(that:)` takes a `@Sendable` predicate, but Swift's inference doesn't reliably propagate `@Sendable` through the member chain. Call sites hit:

> Converting non-Sendable function value to `@Sendable (CustomType) -> Bool` may introduce data races

The key-path matcher doesn't have this failure mode — it captures a **value**, not a closure. That distinction is the whole fix, but nothing in the docs pointed users toward it, and the existing migration note named the warning without giving a remedy.

## API change

`.any(where:)` now names its value parameter `equals:`, which reads as the comparison it performs:

```swift
when(mock.getUser(.any(where: \.id, equals: "123"))).thenReturn(user)
```

The unlabeled form is kept as a `@_disfavoredOverload` delegating to the new one, so **existing call sites compile unchanged**. `@_disfavoredOverload` is load-bearing here: without it the two overloads are ambiguous, since `.any(where: \.id, "123")` can bind to either.

## Docs & skill

Replaced the "may need an explicit `@Sendable` in some positions" advice with a two-tier rule, applied consistently across the skill (`usage.md`, `sendable.md`), the DocC comment on `.any(that:)`, and `docs/swift6-sendable.md`:

1. **Property compared to a value** → `.any(where: \.prop, equals: value)`. Removes the failure mode rather than annotating around it.
2. **Anything a key path can't express** (ranges over a projection, multi-field conditions, negation) → `.any(that: { @Sendable in ... })`.

I deliberately didn't make this a blanket ban on `.any(that:)` — case 2 is genuinely necessary. The `swift6-sendable.md` constraint table also previously lumped `.any` and `.any(that:)` together as "unconstrained", which is misleading: the predicate's *captures* are constrained. Those are now separate rows.

## Testing

- Full suite green (256 tests, no warnings).
- `Examples/` package builds clean — exercises the change as a real downstream client.
- `testAnyWhereMatcher` uses the new labeled form; the pre-existing unlabeled test is retained as the backward-compatibility guard, so both overloads are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the labeled `.any(where:equals:)` argument matcher for property-based comparisons.
  * Preserved the existing `.any(where:)` syntax for compatibility.

* **Documentation**
  * Expanded Swift 6 concurrency guidance for argument matchers.
  * Added recommendations for avoiding `Sendable` inference warnings and using explicit `@Sendable` predicates when needed.

* **Tests**
  * Added coverage for both labeled and existing matcher syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->