### PR TITLE
Support typed throws

### DIFF
--- a/GENERATED_CODE_EXAMPLES.md
+++ b/GENERATED_CODE_EXAMPLES.md
@@ -73,6 +73,60 @@ class PricingServiceMock: Mock, @unchecked Sendable, PricingService {
 ```
 </details>
 
+### Method with typed `throws(E)`
+
+The declared error type is carried into the spy as `TypedThrows<E>`, so the conformance keeps its `throws(E)` signature instead of widening to `any Error`.
+
+```swift
+@Mockable
+protocol PricingService {
+    func price(_ item: String) throws(PricingError) -> Int
+}
+```
+<details>
+<summary>Generated Code</summary>
+
+```swift
+class PricingServiceMock: Mock, @unchecked Sendable, PricingService {
+    func price(_ item: String) throws(PricingError) -> Int {
+        let typedSpy: Spy<String, TypedThrows<PricingError>, Int> = super.price
+        return try adaptTypedThrowing(typedSpy, item)
+    }
+    func price(_ item: ArgMatcher<String>) -> Interaction<String, TypedThrows<PricingError>, Int> {
+        Interaction(item, spy: super.price)
+    }
+}
+```
+</details>
+
+The spy is bound to an explicitly typed local first. The adapter's error type appears only in its `throws(E)` clause and in the spy's effect, and the spy itself comes from a generic subscript — with nothing spelled, both stay open and the compiler reports `generic parameter 'E' could not be inferred`.
+
+Two spellings keep the untyped behaviour, since they mean the same thing as their untyped forms: `throws(any Error)` generates a `Throws` spy, and `throws(Never)` generates a `None` spy whose member needs no `try`.
+
+### Method with `async throws(E)`
+
+```swift
+@Mockable
+protocol PricingService {
+    func price(_ item: String) async throws(PricingError) -> Int
+}
+```
+<details>
+<summary>Generated Code</summary>
+
+```swift
+class PricingServiceMock: Mock, @unchecked Sendable, PricingService {
+    func price(_ item: String) async throws(PricingError) -> Int {
+        let typedSpy: Spy<String, AsyncTypedThrows<PricingError>, Int> = super.price
+        return try await adaptAsyncTypedThrowing(typedSpy, item)
+    }
+    func price(_ item: ArgMatcher<String>) -> Interaction<String, AsyncTypedThrows<PricingError>, Int> {
+        Interaction(item, spy: super.price)
+    }
+}
+```
+</details>
+
 ## Complex Protocol Features
 
 ### Multiple Methods

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The CLI shares its generator with the macro, so it produces the same output and 
 | **Clean, Readable API** | Provides a Mockito-style API that makes tests expressive and easy to maintain. |
 | **Flexible Argument Matching**| Offers powerful argument matchers like `.any` and `.equal`, with `ExpressibleBy...Literal` conformance for cleaner syntax. |
 | **Cross-Mock Call Order Verification** | Verify that method calls occurred in a specific sequence, even across different mock objects with `verifyInOrder()`. |
-| **Effect-Safe Spies** | Models effects like `async` and `throws` as phantom types, ensuring type safety when stubbing. Typed throws (`throws(E)`) carry the declared error type, so stubbing the wrong error is a compile error. See [Typed Throws](#-typed-throws). |
+| **Effect-Safe Spies** | Models effects like `async` and `throws` as phantom types, ensuring type safety when stubbing. Typed throws (`throws(E)`) carry the declared error type, so stubbing the wrong error is a compile error. See the [Usage Reference](docs/usage.md#typed-throws). |
 | **Compact Code Generation** | Keeps the generated code as small and compact as possible. |
 | **Descriptive Error Reporting** | Provides clear and informative error messages when assertions fail, making it easier to debug tests. |
 | **Options to configure the macro generated code** | Exposes the `MockableOptions` OptionSet that enables selecting what and how code gets generated. |
@@ -196,72 +196,6 @@ final class StoreTests: XCTestCase {
     }
 }
 ```
-
----
-
-## 🎯 Typed Throws
-
-Requirements declared with [typed throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md) keep their error type through the mock. The generated conformance stays `throws(E)` rather than widening to `any Error`, so callers catch the concrete type and the compiler checks your stubs against it.
-
-```swift
-@Mockable
-protocol PricingService {
-    func price(_ item: String) throws(PricingError) -> Int
-}
-```
-
-<details>
-<summary>Generated Code</summary>
-
-```swift
-class MockPricingService: Mock, @unchecked Sendable, PricingService {
-    func price(_ item: ArgMatcher<String>) -> Interaction<String, TypedThrows<PricingError>, Int> {
-        Interaction(item, spy: super.price)
-    }
-    func price(_ item: String) throws(PricingError) -> Int {
-        let typedSpy: Spy<String, TypedThrows<PricingError>, Int> = super.price
-        return try adaptTypedThrowing(typedSpy, item)
-    }
-}
-```
-</details>
-
-Stubbing and verification work as they do for untyped `throws`, with one addition: `thenThrow` only accepts the declared error type.
-
-```swift
-let mock = MockPricingService()
-when(mock.price(.any)).thenThrow(.outOfStock)
-
-do {
-    _ = try mock.price("apple")
-} catch {
-    // `error` is already a `PricingError` — no `as?`, no default case.
-    XCTAssertEqual(error, .outOfStock)
-}
-
-verify(mock.price(.any)).called(1)
-```
-
-Stubbing an error the requirement cannot throw no longer compiles:
-
-```swift
-when(mock.price(.any)).thenThrow(NetworkError.offline)
-// ❌ error: cannot convert value of type 'NetworkError' to expected
-//           argument type 'TypedThrows<PricingError>.Failure'
-//           (aka 'PricingError')
-```
-
-`async throws(E)` is supported the same way, producing an `AsyncTypedThrows<E>` spy.
-
-Two spellings deliberately keep the untyped behaviour, since they mean the same thing as their untyped forms:
-
-| Declaration | Effect | Why |
-| --- | --- | --- |
-| `throws(any Error)` | `Throws` | The canonical desugaring of untyped `throws`. |
-| `throws(Never)` | `None` | Cannot throw, so callers need no `try`. |
-
-> [!NOTE]
-> An unstubbed call to a typed-throws method traps rather than throwing. The signature admits only `E`, leaving no way to surface a `MockingError` — the same way non-throwing mocks already report an unstubbed call.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The CLI shares its generator with the macro, so it produces the same output and 
 | **Clean, Readable API** | Provides a Mockito-style API that makes tests expressive and easy to maintain. |
 | **Flexible Argument Matching**| Offers powerful argument matchers like `.any` and `.equal`, with `ExpressibleBy...Literal` conformance for cleaner syntax. |
 | **Cross-Mock Call Order Verification** | Verify that method calls occurred in a specific sequence, even across different mock objects with `verifyInOrder()`. |
-| **Effect-Safe Spies** | Models effects like `async` and `throws` as phantom types, ensuring type safety when stubbing. |
+| **Effect-Safe Spies** | Models effects like `async` and `throws` as phantom types, ensuring type safety when stubbing. Typed throws (`throws(E)`) carry the declared error type, so stubbing the wrong error is a compile error. See [Typed Throws](#-typed-throws). |
 | **Compact Code Generation** | Keeps the generated code as small and compact as possible. |
 | **Descriptive Error Reporting** | Provides clear and informative error messages when assertions fail, making it easier to debug tests. |
 | **Options to configure the macro generated code** | Exposes the `MockableOptions` OptionSet that enables selecting what and how code gets generated. |
@@ -54,6 +54,7 @@ The CLI shares its generator with the macro, so it produces the same output and 
 | Subscripts | ✅ |
 | `async` Methods | ✅ |
 | `throws` Methods | ✅ |
+| `throws(E)` (typed throws) | ✅ |
 | Variadic parameters | ✅ |
 | Closure parameters | ✅ |
 | Metatype parameters | ✅ |
@@ -197,6 +198,70 @@ final class StoreTests: XCTestCase {
 ```
 
 ---
+
+## 🎯 Typed Throws
+
+Requirements declared with [typed throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md) keep their error type through the mock. The generated conformance stays `throws(E)` rather than widening to `any Error`, so callers catch the concrete type and the compiler checks your stubs against it.
+
+```swift
+@Mockable
+protocol PricingService {
+    func price(_ item: String) throws(PricingError) -> Int
+}
+```
+
+<details>
+<summary>Generated Code</summary>
+
+```swift
+class MockPricingService: Mock, @unchecked Sendable, PricingService {
+    func price(_ item: ArgMatcher<String>) -> Interaction<String, TypedThrows<PricingError>, Int> {
+        Interaction(item, spy: super.price)
+    }
+    func price(_ item: String) throws(PricingError) -> Int {
+        let typedSpy: Spy<String, TypedThrows<PricingError>, Int> = super.price
+        return try adaptTypedThrowing(typedSpy, item)
+    }
+}
+```
+</details>
+
+Stubbing and verification work as they do for untyped `throws`, with one addition: `thenThrow` only accepts the declared error type.
+
+```swift
+let mock = MockPricingService()
+when(mock.price(.any)).thenThrow(.outOfStock)
+
+do {
+    _ = try mock.price("apple")
+} catch {
+    // `error` is already a `PricingError` — no `as?`, no default case.
+    XCTAssertEqual(error, .outOfStock)
+}
+
+verify(mock.price(.any)).called(1)
+```
+
+Stubbing an error the requirement cannot throw no longer compiles:
+
+```swift
+when(mock.price(.any)).thenThrow(NetworkError.offline)
+// ❌ error: cannot convert value of type 'NetworkError' to expected
+//           argument type 'TypedThrows<PricingError>.Failure'
+//           (aka 'PricingError')
+```
+
+`async throws(E)` is supported the same way, producing an `AsyncTypedThrows<E>` spy.
+
+Two spellings deliberately keep the untyped behaviour, since they mean the same thing as their untyped forms:
+
+| Declaration | Effect | Why |
+| --- | --- | --- |
+| `throws(any Error)` | `Throws` | The canonical desugaring of untyped `throws`. |
+| `throws(Never)` | `None` | Cannot throw, so callers need no `try`. |
+
+> [!NOTE]
+> An unstubbed call to a typed-throws method traps rather than throwing. The signature admits only `E`, leaving no way to surface a `MockingError` — the same way non-throwing mocks already report an unstubbed call.
 
 ---
 

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -7,11 +7,69 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-public enum EffectType: String {
-    case asyncThrows = "AsyncThrows"
-    case `throws` = "Throws"
-    case `async` = "Async"
-    case none = "None"
+/// The effect a requirement carries, as spelled in the generated spy's type.
+///
+/// Typed-throws requirements (`throws(MyError)`) carry the declared error type so the
+/// generated `Interaction`/`Spy` can name `TypedThrows<MyError>` rather than erasing
+/// to the untyped ``Throws``. `throws(any Error)` is spelled without a type in the
+/// same position, so it is normalized back to the untyped cases by
+/// ``MockableGenerator/getFunctionEffectType(_:)``.
+public enum EffectType: Equatable {
+    case asyncThrows
+    case `throws`
+    case `async`
+    case none
+    /// `throws(E)` — carries the spelled error type `E`.
+    case typedThrows(String)
+    /// `async throws(E)` — carries the spelled error type `E`.
+    case asyncTypedThrows(String)
+
+    /// The type name to write into the generated `Spy`/`Interaction` generic argument list.
+    public var typeName: String {
+        switch self {
+        case .asyncThrows: return "AsyncThrows"
+        case .throws: return "Throws"
+        case .async: return "Async"
+        case .none: return "None"
+        case .typedThrows(let errorType): return "TypedThrows<\(errorType)>"
+        case .asyncTypedThrows(let errorType): return "AsyncTypedThrows<\(errorType)>"
+        }
+    }
+
+    /// Whether the requirement throws, in any form.
+    ///
+    /// Drives the `adapt` vs. `adaptThrowing` choice; previously a substring test on
+    /// the raw value, which the parameterized typed cases would have made fragile.
+    public var isThrowing: Bool {
+        switch self {
+        case .throws, .asyncThrows, .typedThrows, .asyncTypedThrows: return true
+        case .none, .async: return false
+        }
+    }
+
+    /// Whether the requirement is asynchronous.
+    public var isAsync: Bool {
+        switch self {
+        case .async, .asyncThrows, .asyncTypedThrows: return true
+        case .none, .throws, .typedThrows: return false
+        }
+    }
+
+    /// The `Mock` adapter method the generated conformance calls for this effect.
+    ///
+    /// The typed cases use dedicated names rather than `adaptThrowing` overloads. The
+    /// spy passed to the adapter comes from `Mock`'s generic `@dynamicMemberLookup`
+    /// subscript, so its effect is inferred *from* the adapter's parameter; sharing one
+    /// name would leave the solver free to choose the untyped overload and reject the
+    /// expansion. See `Mock.adaptTypedThrowing(_:_:)`.
+    public var adapterName: String {
+        switch self {
+        case .none, .async: return "adapt"
+        case .throws, .asyncThrows: return "adaptThrowing"
+        case .typedThrows: return "adaptTypedThrowing"
+        case .asyncTypedThrows: return "adaptAsyncTypedThrowing"
+        }
+    }
 }
 
 public extension MockableGenerator {
@@ -265,10 +323,10 @@ public extension MockableGenerator {
             #endif
         }
         #if canImport(SwiftSyntax601)
-        genericArgs.append(GenericArgumentSyntax(argument: .init(TypeSyntax(stringLiteral: effectType.rawValue))))
+        genericArgs.append(GenericArgumentSyntax(argument: .init(TypeSyntax(stringLiteral: effectType.typeName))))
         genericArgs.append(GenericArgumentSyntax(argument: .init(outputType)))
         #else
-        genericArgs.append(GenericArgumentSyntax(argument: TypeSyntax(stringLiteral: effectType.rawValue)))
+        genericArgs.append(GenericArgumentSyntax(argument: TypeSyntax(stringLiteral: effectType.typeName)))
         genericArgs.append(GenericArgumentSyntax(argument: outputType))
         #endif
 
@@ -603,17 +661,51 @@ public extension MockableGenerator {
 
     /// Extracts the effect type (throws, async, etc.) from a function declaration.
     ///
-    /// For example, for `async throws -> Int`, this will return `AsyncThrows`.
+    /// For example, for `async throws -> Int`, this will return `AsyncThrows`; for
+    /// `throws(LoadError) -> Int`, `TypedThrows<LoadError>`.
     static func getFunctionEffectType(_ funcDecl: FunctionDeclSyntax) -> EffectType {
         let effects = funcDecl.signature.effectSpecifiers
-        if effects?.throwsClause != nil && effects?.asyncSpecifier != nil {
-            return .asyncThrows
-        } else if effects?.throwsClause != nil {
-            return .throws
-        } else if effects?.asyncSpecifier != nil {
-            return .async
-        } else {
-            return .none
+        let isAsync = effects?.asyncSpecifier != nil
+        guard let throwsClause = effects?.throwsClause else {
+            return isAsync ? .async : .none
+        }
+
+        switch thrownErrorType(throwsClause) {
+        case .untyped:
+            return isAsync ? .asyncThrows : .throws
+        case .never:
+            // `throws(Never)` is a non-throwing function: Swift lets callers invoke it
+            // without `try`, so the generated conformance must not emit one either.
+            return isAsync ? .async : .none
+        case .typed(let errorType):
+            return isAsync ? .asyncTypedThrows(errorType) : .typedThrows(errorType)
+        }
+    }
+
+    /// How a `throws` clause constrains the error type.
+    private enum ThrownErrorType {
+        /// A bare `throws`, or the equivalent explicit `throws(any Error)`.
+        case untyped
+        /// `throws(Never)` — cannot throw at all.
+        case never
+        /// `throws(E)` for a concrete `E`.
+        case typed(String)
+    }
+
+    /// Classifies a `throws` clause by the error type it names.
+    ///
+    /// `throws(any Error)` is the canonical desugaring of an untyped `throws`, so it is
+    /// folded into ``ThrownErrorType/untyped`` and keeps using the existing untyped
+    /// machinery rather than generating a pointless `TypedThrows<any Error>`.
+    private static func thrownErrorType(_ throwsClause: ThrowsClauseSyntax) -> ThrownErrorType {
+        guard let type = throwsClause.type else { return .untyped }
+        switch type.trimmedDescription {
+        case "any Error", "Error":
+            return .untyped
+        case "Never":
+            return .never
+        case let spelled:
+            return .typed(spelled)
         }
     }
 
@@ -745,10 +837,10 @@ public extension MockableGenerator {
         }
 
         #if canImport(SwiftSyntax601)
-        genericArgs.append(GenericArgumentSyntax(argument: .init(TypeSyntax(stringLiteral: effectType.rawValue))))
+        genericArgs.append(GenericArgumentSyntax(argument: .init(TypeSyntax(stringLiteral: effectType.typeName))))
         genericArgs.append(GenericArgumentSyntax(argument: .init(outputType)))
         #else
-        genericArgs.append(GenericArgumentSyntax(argument: TypeSyntax(stringLiteral: effectType.rawValue)))
+        genericArgs.append(GenericArgumentSyntax(argument: TypeSyntax(stringLiteral: effectType.typeName)))
         genericArgs.append(GenericArgumentSyntax(argument: outputType))
         #endif
 

--- a/Sources/MockableGenerator/MockableGenerator+Interactions.swift
+++ b/Sources/MockableGenerator/MockableGenerator+Interactions.swift
@@ -793,7 +793,7 @@ public extension MockableGenerator {
 
     }
 
-    private static func removeAttributes(_ type: TypeSyntaxProtocol) -> TypeSyntax {
+    static func removeAttributes(_ type: TypeSyntaxProtocol) -> TypeSyntax {
         guard let attributedType = type.as(AttributedTypeSyntax.self) else {
             return TypeSyntax(fromProtocol: type)
         }

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -312,10 +312,14 @@ extension MockableGenerator {
         // The spy's input pack mirrors the requirement's parameters, with variadics
         // widened to arrays and `Void` standing in for an empty pack — matching the
         // pack the generated `Interaction` spells and that `adapt` records on.
+        // Attributes are stripped for the same reason `createInteractionReturnType`
+        // strips them: `@escaping`/`@autoclosure` describe how a parameter is passed,
+        // not the type itself, and `Spy<@escaping () -> Void, …>` does not parse. The
+        // spy's pack must match the one the generated `Interaction` spells.
         let inputTypes = funcDecl.signature.parameterClause.parameters.map { parameter -> String in
             let type = parameter.ellipsis != nil
                 ? TypeSyntax(ArrayTypeSyntax(element: parameter.type))
-                : parameter.type
+                : removeAttributes(parameter.type)
             return type.trimmedDescription
         }
         let outputType = funcDecl.signature.returnClause?.type.trimmedDescription ?? "Void"

--- a/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
+++ b/Sources/MockableGenerator/MockableGenerator+ProtocolConformance.swift
@@ -252,37 +252,98 @@ extension MockableGenerator {
         spyAccess: SpyAccess = .inherited
     ) -> CodeBlockSyntax {
         let effectType = getFunctionEffectType(funcDecl)
+        // Typed-throws requirements bind the spy to an explicitly typed local first.
+        // The adapter's error type `E` appears only in its `throws(E)` clause and in
+        // the spy parameter's effect, and the spy itself comes from `Mock`'s generic
+        // `@dynamicMemberLookup` subscript — so with nothing spelled, both the
+        // subscript's `Eff` and the adapter's `E` stay open and the solver reports
+        //   error: generic parameter 'E' could not be inferred
+        // Spelling the spy's type anchors `Eff`, which determines `E`. This is the
+        // same technique the settable-subscript interactions use for their write spy.
+        let spyBinding = typedThrowsSpyBinding(funcDecl, effectType: effectType, spyAccess: spyAccess)
+        let call = baseFunctionRequirementBody(
+            funcDecl,
+            spyAccess: spyAccess,
+            spyIsLocalBinding: spyBinding != nil
+        )
+        // The `return` is load-bearing for `Void`-returning members under
+        // `.composition`: without a contextual result type the solver cannot
+        // infer `Output` for the generic spy subscript, and the compiler
+        // reports a "failed to produce diagnostic" internal error rather than a
+        // usable message.
+        //
+        // `try`/`await` are applied from the effect's own flags so the typed
+        // cases (`throws(E)`, `async throws(E)`) get the same treatment as their
+        // untyped counterparts without another pair of cases to keep in sync.
+        var expression = ExprSyntax(call)
+        if effectType.isAsync {
+            expression = ExprSyntax(AwaitExprSyntax(expression: expression))
+        }
+        if effectType.isThrowing {
+            expression = ExprSyntax(TryExprSyntax(expression: expression))
+        }
         return CodeBlockSyntax {
-            switch effectType {
-            case .none:
-                // The `return` is load-bearing for `Void`-returning members
-                // under `.composition`: without a contextual result type the
-                // solver cannot infer `Output` for the generic spy subscript,
-                // and the compiler reports a "failed to produce diagnostic"
-                // internal error rather than a usable message.
-                ReturnStmtSyntax(expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess))
-            case .asyncThrows:
-                ReturnStmtSyntax(
-                    expression: TryExprSyntax(
-                        expression: AwaitExprSyntax(
-                            expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess)
+            if let spyBinding {
+                spyBinding
+            }
+            ReturnStmtSyntax(expression: expression)
+        }
+    }
+
+    /// The local constant a typed-throws requirement binds its spy to.
+    static let typedThrowsSpyBindingName = "typedSpy"
+
+    /// Builds `let typedSpy: Spy<Inputs…, TypedThrows<E>, Output> = super.<name>` for a
+    /// typed-throws requirement, or `nil` for every other effect.
+    ///
+    /// See ``functionRequirementBody(_:spyAccess:)`` for why the type must be spelled.
+    private static func typedThrowsSpyBinding(
+        _ funcDecl: FunctionDeclSyntax,
+        effectType: EffectType,
+        spyAccess: SpyAccess
+    ) -> VariableDeclSyntax? {
+        switch effectType {
+        case .none, .async, .throws, .asyncThrows:
+            return nil
+        case .typedThrows, .asyncTypedThrows:
+            break
+        }
+
+        // The spy's input pack mirrors the requirement's parameters, with variadics
+        // widened to arrays and `Void` standing in for an empty pack — matching the
+        // pack the generated `Interaction` spells and that `adapt` records on.
+        let inputTypes = funcDecl.signature.parameterClause.parameters.map { parameter -> String in
+            let type = parameter.ellipsis != nil
+                ? TypeSyntax(ArrayTypeSyntax(element: parameter.type))
+                : parameter.type
+            return type.trimmedDescription
+        }
+        let outputType = funcDecl.signature.returnClause?.type.trimmedDescription ?? "Void"
+        let arguments = (inputTypes.isEmpty ? ["Void"] : inputTypes)
+            + [effectType.typeName, outputType]
+        let spyType = TypeSyntax(stringLiteral: "Spy<\(arguments.joined(separator: ", "))>")
+
+        return VariableDeclSyntax(
+            bindingSpecifier: .keyword(.let, trailingTrivia: .space),
+            bindings: PatternBindingListSyntax {
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(
+                        identifier: .identifier(typedThrowsSpyBindingName)
+                    ),
+                    typeAnnotation: TypeAnnotationSyntax(
+                        colon: .colonToken(trailingTrivia: .space),
+                        type: spyType
+                    ),
+                    initializer: InitializerClauseSyntax(
+                        equal: .equalToken(leadingTrivia: .space, trailingTrivia: .space),
+                        value: spyAccess.spyReference(
+                            funcDecl.name,
+                            isStatic: funcDecl.modifiers.contains(where: \.isStatic)
                         )
                     )
                 )
-            case .throws:
-                ReturnStmtSyntax(
-                    expression: TryExprSyntax(
-                        expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess)
-                    )
-                )
-            case .async:
-                ReturnStmtSyntax(
-                    expression: AwaitExprSyntax(
-                        expression: baseFunctionRequirementBody(funcDecl, spyAccess: spyAccess)
-                    )
-                )
             }
-        }
+        )
     }
     
     /// Generates the base function call for a function requirement body.
@@ -290,7 +351,8 @@ extension MockableGenerator {
     /// This function creates a `FunctionCallExprSyntax` that calls the appropriate `adapt` function.
     private static func baseFunctionRequirementBody(
         _ functionDecl: FunctionDeclSyntax,
-        spyAccess: SpyAccess = .inherited
+        spyAccess: SpyAccess = .inherited,
+        spyIsLocalBinding: Bool = false
     ) -> FunctionCallExprSyntax {
         let effectType = getFunctionEffectType(functionDecl)
         return adaptCall(
@@ -299,7 +361,8 @@ extension MockableGenerator {
             parameters: functionDecl.signature.parameterClause.parameters
                 .map({ ExprSyntax(DeclReferenceExprSyntax(baseName: $0.secondName ?? $0.firstName)) }),
             spyAccess: spyAccess,
-            isStatic: functionDecl.modifiers.contains(where: \.isStatic)
+            isStatic: functionDecl.modifiers.contains(where: \.isStatic),
+            spyIsLocalBinding: spyIsLocalBinding
         )
     }
 
@@ -311,21 +374,31 @@ extension MockableGenerator {
     /// ```swift
     /// adapt(super.myMethod, param1)
     /// ```
+    ///
+    /// - Parameter spyIsLocalBinding: When `true`, the spy has already been bound to an
+    ///   explicitly typed local (see ``typedThrowsSpyBindingName``), so the call passes
+    ///   that constant instead of re-deriving the spy through `super.`.
     private static func adaptCall(
         effectType: EffectType,
         requirementName: TokenSyntax,
         parameters: [ExprSyntax],
         spyAccess: SpyAccess = .inherited,
-        isStatic: Bool = false
+        isStatic: Bool = false,
+        spyIsLocalBinding: Bool = false
     ) -> FunctionCallExprSyntax {
-        let adaptingName = "adapt" + (effectType.rawValue.contains("Throws") ? "Throwing" : "")
+        let adaptingName = effectType.adapterName
         return FunctionCallExprSyntax(
             calledExpression: spyAccess.adapterCallee(adaptingName),
             leftParen: .leftParenToken(),
             arguments: LabeledExprListSyntax {
-                // super.myMethodName — or mock.myMethodName when composing
+                // super.myMethodName — or mock.myMethodName when composing, or the
+                // typed local binding for typed-throws requirements.
                 LabeledExprSyntax(
-                    expression: spyAccess.spyReference(requirementName, isStatic: isStatic)
+                    expression: spyIsLocalBinding
+                        ? ExprSyntax(DeclReferenceExprSyntax(
+                            baseName: .identifier(typedThrowsSpyBindingName)
+                        ))
+                        : spyAccess.spyReference(requirementName, isStatic: isStatic)
                 )
 
                 // param1, param2... — or () when the requirement has no

--- a/Sources/SwiftMocking/Action.swift
+++ b/Sources/SwiftMocking/Action.swift
@@ -53,6 +53,37 @@ extension Action where Eff == Throws {
     }
 }
 
+extension Action where Eff: SyncTypedThrowingEffect {
+    /// Registers a throwing synchronous action.
+    ///
+    /// The handler is constrained to the effect's declared error type, so an action
+    /// cannot introduce an error the requirement is not allowed to throw.
+    public func `do`(_ handler: @escaping @Sendable (repeat each I) throws(Eff.Failure) -> Void) {
+        throwingPerformer = { invocation in
+            try handler(repeat each invocation.arguments)
+        }
+    }
+
+    func perform(_ invocation: Invocation<repeat each I>) throws {
+        try throwingPerformer?(invocation)
+    }
+}
+
+extension Action where Eff: AsyncTypedThrowingEffect {
+    /// Registers an asynchronous throwing action.
+    ///
+    /// See the synchronous overload for why the handler's error type is constrained.
+    public func `do`(_ handler: @escaping @Sendable (repeat each I) async throws(Eff.Failure) -> Void) {
+        asyncThrowingPerformer = { invocation in
+            try await handler(repeat each invocation.arguments)
+        }
+    }
+
+    func perform(_ invocation: Invocation<repeat each I>) async throws {
+        try await asyncThrowingPerformer?(invocation)
+    }
+}
+
 extension Action where Eff == Async {
     /// Registers an asynchronous action.
     public func `do`(_ handler: @escaping @Sendable (repeat each I) async -> Void) {

--- a/Sources/SwiftMocking/Arrange.swift
+++ b/Sources/SwiftMocking/Arrange.swift
@@ -56,6 +56,54 @@ public extension Arrange where Eff == Throws {
     }
 }
 
+// MARK: - TypedThrows
+public extension Arrange where Eff: SyncTypedThrowingEffect {
+    func thenReturn(_ output: Output) where Output: Sendable {
+        interaction.spy.createStub(for: interaction.invocationMatcher).thenReturn(output)
+    }
+
+    /// Stubs the interaction to throw, constrained to the requirement's declared error type.
+    func thenThrow(_ error: Eff.Failure) where Eff.Failure: Sendable {
+        interaction.spy.createStub(for: interaction.invocationMatcher).thenThrow(error)
+    }
+
+    func thenReturn(
+        _ handler: @escaping @Sendable (repeat each I) throws(Eff.Failure) -> Output
+    ) where repeat each I: Sendable {
+        interaction.spy.createStub(for: interaction.invocationMatcher).thenReturn(handler)
+    }
+
+    func `do`(_ handler: @escaping @Sendable (repeat each I) throws(Eff.Failure) -> Void) {
+        let action = Action<repeat each I, Eff>(invocationMatcher: interaction.invocationMatcher)
+        action.do(handler)
+        interaction.spy.registerAction(action)
+    }
+}
+
+// MARK: - AsyncTypedThrows
+public extension Arrange where Eff: AsyncTypedThrowingEffect {
+    func thenReturn(_ output: Output) where Output: Sendable {
+        interaction.spy.createStub(for: interaction.invocationMatcher).thenReturn(output)
+    }
+
+    /// Stubs the interaction to throw, constrained to the requirement's declared error type.
+    func thenThrow(_ error: Eff.Failure) where Eff.Failure: Sendable {
+        interaction.spy.createStub(for: interaction.invocationMatcher).thenThrow(error)
+    }
+
+    func thenReturn(
+        _ handler: @escaping @Sendable (repeat each I) async throws(Eff.Failure) -> Output
+    ) where repeat each I: Sendable {
+        interaction.spy.createStub(for: interaction.invocationMatcher).thenReturn(handler)
+    }
+
+    func `do`(_ handler: @escaping @Sendable (repeat each I) async throws(Eff.Failure) -> Void) {
+        let action = Action<repeat each I, Eff>(invocationMatcher: interaction.invocationMatcher)
+        action.do(handler)
+        interaction.spy.registerAction(action)
+    }
+}
+
 // MARK: - Async
 public extension Arrange where Eff == Async {
     func thenReturn(_ output: Output) where Output: Sendable {

--- a/Sources/SwiftMocking/Assert.swift
+++ b/Sources/SwiftMocking/Assert.swift
@@ -154,6 +154,101 @@ extension Assert where Eff == Throws {
     }
 }
 
+extension Assert where Eff: SyncTypedThrowingEffect {
+    /// Asserts that the spy's method threw an error.
+    ///
+    /// The matcher stays `ArgMatcher<any Error>` rather than being narrowed to the
+    /// declared error type: matchers like ``ArgMatcher/anyError()`` and
+    /// ``ArgMatcher/error(_:)`` are shared with the untyped effects, and stubbing
+    /// already guarantees any collected error is an `Eff.Failure`.
+    /// - Parameter errorMatcher: An optional ``ArgMatcher`` for `Error`. If `nil`, asserts that any error was thrown.
+    /// - Throws:
+    ///   - ``MockingError/didNotThrow`` if no error was thrown.
+    ///   - ``MockingError/didNotMatchThrown(_:)`` if an `errorMatcher` is provided and no thrown error matches it.
+    public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) throws {
+        var errors = [any Error]()
+        for invocation in spy.invocations {
+            for stub in spy.stubs {
+                guard let stubbedReturn = stub.returnValue(for: invocation) else {
+                    continue
+                }
+                guard stub.invocationMatcher.isMatchedBy(invocation) else {
+                    continue
+                }
+                if let invocationMatcher {
+                    if invocationMatcher.isMatchedBy(invocation) {
+                        Self.collectTypedErrors(stubbedReturn, errors: &errors)
+                    }
+                } else {
+                    Self.collectTypedErrors(stubbedReturn, errors: &errors)
+                }
+            }
+        }
+
+        if errors.isEmpty {
+            throw MockingError.didNotThrow
+        }
+
+        if let errorMatcher, !errors.contains(where: errorMatcher.callAsFunction) {
+            throw MockingError.didNotMatchThrown(errors)
+        }
+    }
+
+    private static func collectTypedErrors<O>(_ result: Return<Eff, O>, errors: inout [any Error]) {
+        guard let resolved = result.resolveIfSynchronous() else {
+            return
+        }
+        if case .failure(let error) = resolved {
+            errors.append(error)
+        }
+    }
+}
+
+extension Assert where Eff: AsyncTypedThrowingEffect {
+    /// Asserts that the spy's asynchronous method threw an error.
+    ///
+    /// See the synchronous overload for why the matcher is not narrowed to the
+    /// declared error type.
+    /// - Parameter errorMatcher: An optional ``ArgMatcher`` for `Error`. If `nil`, asserts that any error was thrown.
+    /// - Throws:
+    ///   - ``MockingError/didNotThrow`` if no error was thrown.
+    ///   - ``MockingError/didNotMatchThrown(_:)`` if an `errorMatcher` is provided and no thrown error matches it.
+    public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) async throws {
+        var errors = [any Error]()
+        for invocation in spy.invocations {
+            for stub in spy.stubs {
+                guard let stubbedReturn = stub.returnValue(for: invocation) else {
+                    continue
+                }
+                guard stub.invocationMatcher.isMatchedBy(invocation) else {
+                    continue
+                }
+                if let invocationMatcher {
+                    if invocationMatcher.isMatchedBy(invocation) {
+                        await Self.collectTypedErrorsAsync(stubbedReturn, errors: &errors)
+                    }
+                } else {
+                    await Self.collectTypedErrorsAsync(stubbedReturn, errors: &errors)
+                }
+            }
+        }
+
+        if errors.isEmpty {
+            throw MockingError.didNotThrow
+        }
+
+        if let errorMatcher, !errors.contains(where: errorMatcher.callAsFunction) {
+            throw MockingError.didNotMatchThrown(errors)
+        }
+    }
+
+    private static func collectTypedErrorsAsync<O>(_ result: Return<Eff, O>, errors: inout [any Error]) async {
+        if case .failure(let error) = await result.resolveAsync() {
+            errors.append(error)
+        }
+    }
+}
+
 extension Assert where Eff == AsyncThrows {
     /// Asserts that the spy's asynchronous method threw an error.
     /// - Parameter errorMatcher: An optional ``ArgMatcher`` for `Error` to specify the expected error. If `nil`, asserts that any error was thrown.

--- a/Sources/SwiftMocking/Effects.swift
+++ b/Sources/SwiftMocking/Effects.swift
@@ -14,11 +14,63 @@ public protocol Effect: Sendable { }
 /// Represents a method that can throw an error.
 public enum Throws: Effect, Sendable { }
 
+/// Represents a method that can throw exactly one concrete error type.
+///
+/// This is the typed-throws counterpart of ``Throws``, carrying the declared error
+/// type as a phantom parameter so it survives into the spy's type. A requirement
+/// `func load() throws(LoadError) -> Data` produces a
+/// `Spy<Void, TypedThrows<LoadError>, Data>`, and the generated conformance rethrows
+/// as `throws(LoadError)` — the error type is checked at compile time rather than
+/// erased to `any Error`.
+///
+/// Stubbing is constrained to match: `thenThrow` on such a spy only accepts a
+/// `LoadError`, so a mismatched error is a compile error instead of a test that
+/// fails at runtime.
+public enum TypedThrows<E: Error>: Effect, Sendable { }
+
+/// An effect that names the single concrete error type its method can throw.
+///
+/// Conformance projects that error type out of the phantom effect as ``Failure``, so
+/// generic code constrains on the effect (`where Effects: TypedThrowingEffect`) and
+/// still refers to the concrete error as `Effects.Failure`. Writing the constraint as
+/// `Effects == TypedThrows<E>` on each extension would work too, but `some Error` is
+/// not permitted in an extension's `where` clause, and an associated type keeps the
+/// synchronous and asynchronous cases sharing one constraint shape.
+public protocol TypedThrowingEffect: Effect {
+    /// The concrete error type methods with this effect are declared to throw.
+    associatedtype Failure: Error
+}
+
+/// A synchronous typed-throwing effect.
+///
+/// Extensions constrain on this rather than on `Effects == TypedThrows<E>` because
+/// `some Error` is not permitted in an extension's `where` clause. A marker protocol
+/// separates the synchronous and asynchronous cases — which need different call
+/// signatures — while both keep projecting ``TypedThrowingEffect/Failure``.
+public protocol SyncTypedThrowingEffect: TypedThrowingEffect { }
+
+/// An asynchronous typed-throwing effect. See ``SyncTypedThrowingEffect``.
+public protocol AsyncTypedThrowingEffect: TypedThrowingEffect { }
+
+extension TypedThrows: SyncTypedThrowingEffect {
+    public typealias Failure = E
+}
+
 /// Represents an asynchronous method.
 public enum Async: Effect, Sendable { }
 
 /// Represents a method that can also throw an error.
 public enum AsyncThrows: Effect, Sendable { }
+
+/// Represents an asynchronous method that can throw exactly one concrete error type.
+///
+/// The `async` counterpart of ``TypedThrows`` — see that type for how the declared
+/// error type is carried and enforced.
+public enum AsyncTypedThrows<E: Error>: Effect, Sendable { }
+
+extension AsyncTypedThrows: AsyncTypedThrowingEffect {
+    public typealias Failure = E
+}
 
 /// Represents a method that has no special effects (neither throws nor is asynchronous).
 public enum None: Effect, Sendable { }

--- a/Sources/SwiftMocking/Mock+Adapters.swift
+++ b/Sources/SwiftMocking/Mock+Adapters.swift
@@ -128,6 +128,81 @@ public extension Mock {
         return result
     }
 
+    /// Adapts a typed-throwing spy call for static method mocking.
+    ///
+    /// The declared error type flows from the spy's effect into this adapter's
+    /// `throws(E)` clause, so the generated conformance keeps the requirement's
+    /// typed-throws signature instead of widening it to `any Error`.
+    ///
+    /// Named distinctly from ``adaptThrowing(_:_:)`` rather than overloading it: the
+    /// spy argument comes from `Mock`'s generic `@dynamicMemberLookup` subscript, so
+    /// nothing anchors `Eff` at the call site and the effect is inferred *from* the
+    /// adapter's parameter. With both spelled `adaptThrowing`, the solver has no basis
+    /// to prefer the typed overload and picks the untyped one, producing
+    /// `error: thrown expression type 'any Error' cannot be converted to error type 'E'`
+    /// inside the expansion. A separate name makes the generator's choice explicit.
+    ///
+    /// - Parameters:
+    ///   - spy: The typed-throwing spy instance to invoke.
+    ///   - input: The input arguments to pass to the spy.
+    /// - Returns: The result of the spy invocation.
+    /// - Throws: The stubbed error, typed as `E`.
+    static func adaptTypedThrowing<each I, E: Error, O>(
+        _ spy: Spy<repeat each I, TypedThrows<E>, O>,
+        _ input: repeat each I
+    ) throws(E) -> O {
+        try spy(repeat each input)
+    }
+
+    /// Adapts a typed-throwing spy call for instance method mocking.
+    ///
+    /// See the static overload for how the declared error type is preserved and why
+    /// this is not an `adaptThrowing` overload.
+    ///
+    /// - Parameters:
+    ///   - spy: The typed-throwing spy instance to invoke.
+    ///   - input: The input arguments to pass to the spy.
+    /// - Returns: The result of the spy invocation.
+    /// - Throws: The stubbed error, typed as `E`.
+    func adaptTypedThrowing<each I, E: Error, O>(
+        _ spy: Spy<repeat each I, TypedThrows<E>, O>,
+        _ input: repeat each I
+    ) throws(E) -> O {
+        try spy(repeat each input)
+    }
+
+    /// Adapts an async typed-throwing spy call for static method mocking.
+    ///
+    /// See ``adaptTypedThrowing(_:_:)`` for how the declared error type is preserved.
+    ///
+    /// - Parameters:
+    ///   - spy: The async typed-throwing spy instance to invoke.
+    ///   - input: The input arguments to pass to the spy.
+    /// - Returns: The result of the async spy invocation.
+    /// - Throws: The stubbed error, typed as `E`.
+    static func adaptAsyncTypedThrowing<each I, E: Error, O>(
+        _ spy: Spy<repeat each I, AsyncTypedThrows<E>, O>,
+        _ input: repeat each I
+    ) async throws(E) -> O {
+        try await spy(repeat each input)
+    }
+
+    /// Adapts an async typed-throwing spy call for instance method mocking.
+    ///
+    /// See the static overload for how the declared error type is preserved.
+    ///
+    /// - Parameters:
+    ///   - spy: The async typed-throwing spy instance to invoke.
+    ///   - input: The input arguments to pass to the spy.
+    /// - Returns: The result of the async spy invocation.
+    /// - Throws: The stubbed error, typed as `E`.
+    func adaptAsyncTypedThrowing<each I, E: Error, O>(
+        _ spy: Spy<repeat each I, AsyncTypedThrows<E>, O>,
+        _ input: repeat each I
+    ) async throws(E) -> O {
+        try await spy(repeat each input)
+    }
+
     /// Adapts an async throwing spy call for static method mocking.
     ///
     /// This adapter handles methods that are both async and throwing in generated

--- a/Sources/SwiftMocking/Return.swift
+++ b/Sources/SwiftMocking/Return.swift
@@ -272,8 +272,12 @@ extension Return where Effects: TypedThrowingEffect {
                 return .failure(error)
             }
         }
-        // A non-async `thenReturn` handler on an async requirement stores a
-        // throwing resolver, so both must be honored here.
+        // A non-throwing async `thenReturn` handler stores an async resolver, and a
+        // non-async one stores a throwing resolver, so every resolver a `Stub` can
+        // install must be honored here — not just the async throwing one.
+        if let asyncResolver {
+            return .success(await asyncResolver())
+        }
         guard let throwingResolver else {
             fatalError("Return has no resolver.")
         }

--- a/Sources/SwiftMocking/Return.swift
+++ b/Sources/SwiftMocking/Return.swift
@@ -204,6 +204,99 @@ extension Return where Effects == Throws {
     }
 }
 
+extension Return where Effects: TypedThrowingEffect {
+    /// Resolves the deferred value into a `Result`.
+    ///
+    /// The failure type stays `any Error` rather than the declared `E`: a `Return` can
+    /// also carry a ``MockingError`` for an unstubbed call, which is by construction not
+    /// an `E`. Narrowing to `E` happens at the call boundary in `Spy`, which is the only
+    /// place that can act on the distinction (rethrow vs. trap).
+    /// - Returns: The stored result for this return value.
+    func resolve() -> Result<R, any Error> {
+        if let storedError {
+            return .failure(storedError)
+        }
+        if let storedValue {
+            return .success(storedValue)
+        }
+        guard let throwingResolver else {
+            fatalError("Return has no resolver.")
+        }
+        do {
+            return .success(try throwingResolver())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Attempts to resolve the value synchronously if a synchronous resolver exists.
+    /// - Returns: The stored result if a synchronous resolver is present, otherwise `nil`.
+    func resolveIfSynchronous() -> Result<R, any Error>? {
+        if let storedError {
+            return .failure(storedError)
+        }
+        if let storedValue {
+            return .success(storedValue)
+        }
+        guard let throwingResolver else { return nil }
+        do {
+            return .success(try throwingResolver())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Creates a `Return` instance that represents an error.
+    /// - Parameter error: The error to be returned.
+    /// - Returns: A `Return` instance encapsulating the error.
+    static func error<E: Error>(_ error: E) -> Return<Effects, R> {
+        Return(error: error)
+    }
+
+    /// Resolves the deferred value asynchronously into a `Result`.
+    ///
+    /// The failure type stays `any Error` for the same reason as the synchronous
+    /// case — see ``resolve()``.
+    /// - Returns: The stored result for this return value.
+    func resolveAsync() async -> Result<R, any Error> {
+        if let storedError {
+            return .failure(storedError)
+        }
+        if let storedValue {
+            return .success(storedValue)
+        }
+        if let asyncThrowingResolver {
+            do {
+                return .success(try await asyncThrowingResolver())
+            } catch {
+                return .failure(error)
+            }
+        }
+        // A non-async `thenReturn` handler on an async requirement stores a
+        // throwing resolver, so both must be honored here.
+        guard let throwingResolver else {
+            fatalError("Return has no resolver.")
+        }
+        do {
+            return .success(try throwingResolver())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Creates a `Return` from a throwing synchronous closure.
+    /// - Parameter producer: A closure that can throw and produces the value.
+    init(_ producer: @escaping @Sendable () throws -> R) {
+        self.init(throwingValue: producer)
+    }
+
+    /// Creates a `Return` from an asynchronous throwing closure.
+    /// - Parameter producer: An async closure that can throw and produces the value.
+    init(_ producer: @escaping @Sendable () async throws -> R) {
+        self.init(asyncThrowingValue: producer)
+    }
+}
+
 extension Return where Effects == Async {
     /// Resolves the deferred value asynchronously into a `Result`.
     /// - Returns: The stored result for this return value.

--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -337,6 +337,166 @@ extension Spy where Effects == Throws {
     }
 }
 
+// MARK: Typed throwing
+extension Spy where Effects: TypedThrowingEffect {
+    /// Narrows a resolved failure to the effect's declared error type.
+    ///
+    /// A `Return` for a typed-throwing spy can hold two very different failures: an
+    /// error the test stubbed (necessarily an `Effects.Failure`, because `thenThrow`
+    /// only accepts one), or a ``MockingError`` raised by the framework for an
+    /// unstubbed call. Only the former can cross a `throws(Failure)` boundary.
+    ///
+    /// The latter traps rather than propagating, matching how non-throwing spies
+    /// (`Effects == None`, `Effects == Async`) already report an unstubbed call: the
+    /// method's signature leaves no way to surface it, and an unstubbed call is a
+    /// test-authoring mistake rather than a condition under test.
+    private static func narrow(_ error: any Error) -> Effects.Failure {
+        if let typed = error as? Effects.Failure {
+            return typed
+        }
+        if let mockingError = error as? MockingError {
+            fatalError("MockingError: \(mockingError.message)")
+        }
+        fatalError(
+            """
+            Spy stubbed with an error of type \(type(of: error)) but the requirement \
+            is declared to throw \(Effects.Failure.self).
+            """
+        )
+    }
+}
+
+// MARK: Typed throwing (synchronous)
+extension Spy where Effects: SyncTypedThrowingEffect {
+    /// Calls the spy's method, rethrowing the stubbed error as the declared error type.
+    /// - Parameter input: The arguments for the method call.
+    /// - Returns: The output of the method if it doesn't throw.
+    /// - Throws: The stubbed error, typed as the requirement's declared error type.
+    @discardableResult
+    public func callAsFunction(_ input: repeat each Input) throws(Effects.Failure) -> Output {
+        let invocation = Invocation(arguments: repeat each input)
+        let action = matchingAction(invocation: invocation)
+        let result: Return<Effects, Output>
+        do {
+            result = try invoke(repeat each input)
+        } catch {
+            throw Self.narrow(error)
+        }
+        if let action {
+            do {
+                try action.perform(invocation)
+            } catch {
+                throw Self.narrow(error)
+            }
+        }
+        switch result.resolve() {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw Self.narrow(error)
+        }
+    }
+
+    public func asFunction() -> @Sendable (repeat each Input) throws(Effects.Failure) -> Output {
+        return { (args: repeat each Input) throws(Effects.Failure) in
+            try self(repeat each args)
+        }
+    }
+
+    /// Verifies that the spy's method threw an error matching the given `errorMatcher`.
+    /// - Parameter errorMatcher: An ``ArgMatcher`` for `Error` to specify the expected error.
+    /// - Returns: `true` if a matching error was thrown, `false` otherwise.
+    public func verifyThrows(_ errorMatcher: ArgMatcher<any Error>) -> Bool {
+        var doesThrow = false
+        for invocation in snapshotInvocations() {
+            for stub in snapshotStubs() where stub.invocationMatcher.isMatchedBy(invocation) {
+                guard let stubbedReturn = stub.returnValue(for: invocation) else {
+                    continue
+                }
+                switch stubbedReturn.resolve() {
+                case .success:
+                    break
+                case .failure(let error):
+                    doesThrow = errorMatcher(error)
+                }
+            }
+        }
+        return doesThrow
+    }
+
+    /// Verifies that the spy's method threw any error.
+    /// - Returns: `true` if any error was thrown, `false` otherwise.
+    public func verifyThrows() -> Bool {
+        verifyThrows(.anyError())
+    }
+}
+
+// MARK: Typed throwing (asynchronous)
+extension Spy where Effects: AsyncTypedThrowingEffect {
+    /// Calls the spy's method asynchronously, rethrowing the stubbed error as the
+    /// declared error type.
+    /// - Parameter input: The arguments for the method call.
+    /// - Returns: The output of the method if it doesn't throw.
+    /// - Throws: The stubbed error, typed as the requirement's declared error type.
+    @discardableResult
+    public func callAsFunction(_ input: repeat each Input) async throws(Effects.Failure) -> Output {
+        let invocation = Invocation(arguments: repeat each input)
+        let action = matchingAction(invocation: invocation)
+        let result: Return<Effects, Output>
+        do {
+            result = try invoke(repeat each input)
+        } catch {
+            throw Self.narrow(error)
+        }
+        if let action {
+            do {
+                try await action.perform(invocation)
+            } catch {
+                throw Self.narrow(error)
+            }
+        }
+        switch await result.resolveAsync() {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw Self.narrow(error)
+        }
+    }
+
+    public func asFunction() -> @Sendable (repeat each Input) async throws(Effects.Failure) -> Output {
+        return { (args: repeat each Input) async throws(Effects.Failure) in
+            try await self(repeat each args)
+        }
+    }
+
+    /// Verifies that the spy's method threw an error matching the given `errorMatcher`.
+    /// - Parameter errorMatcher: An ``ArgMatcher`` for `Error` to specify the expected error.
+    /// - Returns: `true` if a matching error was thrown, `false` otherwise.
+    public func verifyThrows(_ errorMatcher: ArgMatcher<any Error>) async -> Bool {
+        var doesThrow = false
+        for invocation in snapshotInvocations() {
+            for stub in snapshotStubs() where stub.invocationMatcher.isMatchedBy(invocation) {
+                guard let stubbedReturn = stub.returnValue(for: invocation) else {
+                    continue
+                }
+                switch await stubbedReturn.resolveAsync() {
+                case .success:
+                    break
+                case .failure(let error):
+                    doesThrow = errorMatcher(error)
+                }
+            }
+        }
+        return doesThrow
+    }
+
+    /// Verifies that the spy's method threw any error.
+    /// - Returns: `true` if any error was thrown, `false` otherwise.
+    public func verifyThrows() async -> Bool {
+        await verifyThrows(.anyError())
+    }
+}
+
 // MARK: None throwing
 extension Spy where Effects == None {
     /// Calls the spy's method, expecting it not to throw an error.

--- a/Sources/SwiftMocking/Spy.swift
+++ b/Sources/SwiftMocking/Spy.swift
@@ -323,7 +323,7 @@ extension Spy where Effects == Throws {
                 case .success:
                     break
                 case .failure(let error):
-                    doesThrow = errorMatcher(error)
+                    doesThrow = doesThrow || errorMatcher(error)
                 }
             }
         }
@@ -417,7 +417,7 @@ extension Spy where Effects: SyncTypedThrowingEffect {
                 case .success:
                     break
                 case .failure(let error):
-                    doesThrow = errorMatcher(error)
+                    doesThrow = doesThrow || errorMatcher(error)
                 }
             }
         }
@@ -483,7 +483,7 @@ extension Spy where Effects: AsyncTypedThrowingEffect {
                 case .success:
                     break
                 case .failure(let error):
-                    doesThrow = errorMatcher(error)
+                    doesThrow = doesThrow || errorMatcher(error)
                 }
             }
         }
@@ -610,7 +610,7 @@ extension Spy where Effects == AsyncThrows {
                 case .success:
                     break
                 case .failure(let error):
-                    doesThrow = errorMatcher(error)
+                    doesThrow = doesThrow || errorMatcher(error)
                 }
             }
         }

--- a/Sources/SwiftMocking/Stub.swift
+++ b/Sources/SwiftMocking/Stub.swift
@@ -122,6 +122,94 @@ extension Stub where Effects == Throws {
     }
 }
 
+extension Stub where Effects: SyncTypedThrowingEffect {
+    /// Defines the return value for this stub.
+    /// - Parameter output: The value to return when this stub is matched.
+    public func thenReturn(_ output: O) where O: Sendable {
+        self.output = { _ in Return.value(output) }
+    }
+
+    /// Defines a dynamic return value using a closure that receives the method arguments.
+    /// - Parameter handler: A closure that takes the method arguments and returns the desired output.
+    public func thenReturn(_ handler: @escaping @Sendable (repeat each I) -> O) {
+        self.output = { invocation in
+            let returnValue = handler(repeat each invocation.arguments)
+            return Return.value(returnValue)
+        }
+    }
+
+    /// Defines an error to be thrown when this stub is matched.
+    ///
+    /// Unlike the untyped ``Throws`` overload, this accepts only the error type the
+    /// requirement declares: stubbing an unrelated error is a compile error rather
+    /// than a trap at call time.
+    /// - Parameter error: The error to throw.
+    public func thenThrow(_ error: Effects.Failure) where Effects.Failure: Sendable {
+        self.output = { _ in Return.error(error) }
+    }
+
+    /// Defines a dynamic return value that can throw before producing the result.
+    /// - Parameter handler: A closure that can throw and returns the desired output.
+    public func thenReturn(
+        _ handler: @escaping @Sendable (repeat each I) throws(Effects.Failure) -> O
+    ) where repeat each I: Sendable {
+        self.output = { invocation in
+            Return(throwingValue: {
+                try handler(repeat each invocation.arguments)
+            })
+        }
+    }
+}
+
+extension Stub where Effects: AsyncTypedThrowingEffect {
+    /// Defines the return value for this stub.
+    /// - Parameter output: The value to return when this stub is matched.
+    public func thenReturn(_ output: O) where O: Sendable {
+        self.output = { _ in Return.value(output) }
+    }
+
+    /// Defines a dynamic return value using a closure that receives the method arguments.
+    /// - Parameter handler: A closure that takes the method arguments and returns the desired output.
+    public func thenReturn(_ handler: @escaping @Sendable (repeat each I) -> O) {
+        self.output = { invocation in
+            let returnValue = handler(repeat each invocation.arguments)
+            return Return.value(returnValue)
+        }
+    }
+
+    /// Defines an error to be thrown when this stub is matched.
+    ///
+    /// See the synchronous overload for why the error type is constrained.
+    /// - Parameter error: The error to throw.
+    public func thenThrow(_ error: Effects.Failure) where Effects.Failure: Sendable {
+        self.output = { _ in Return.error(error) }
+    }
+
+    /// Defines a dynamic return value using an asynchronous closure.
+    /// - Parameter handler: An async closure that returns the desired output.
+    public func thenReturn(
+        _ handler: @escaping @Sendable (repeat each I) async -> O
+    ) where repeat each I: Sendable {
+        self.output = { invocation in
+            Return(asyncValue: {
+                await handler(repeat each invocation.arguments)
+            })
+        }
+    }
+
+    /// Defines a dynamic return value using an asynchronous closure that can throw.
+    /// - Parameter handler: An async closure that returns the desired output or throws.
+    public func thenReturn(
+        _ handler: @escaping @Sendable (repeat each I) async throws(Effects.Failure) -> O
+    ) where repeat each I: Sendable {
+        self.output = { invocation in
+            Return(asyncThrowingValue: {
+                try await handler(repeat each invocation.arguments)
+            })
+        }
+    }
+}
+
 extension Stub where Effects == Async {
     /// Defines the return value for this stub.
     /// - Parameter output: The value to return when this stub is matched.

--- a/Sources/SwiftMocking/TestSupport.swift
+++ b/Sources/SwiftMocking/TestSupport.swift
@@ -467,6 +467,55 @@ public extension Assert where Eff == AsyncThrows {
     }
 }
 
+public extension Assert where Eff: SyncTypedThrowingEffect {
+    /// Asserts that the mocked method threw an error.
+    ///
+    /// The typed-throws counterpart of the ``Throws`` overload. The matcher stays
+    /// `ArgMatcher<any Error>` so `.anyError()` and `.error(_:)` work unchanged.
+    ///
+    /// - Parameter errorMatcher: An `ArgMatcher<any Error>` to specify the expected error.
+    ///   Defaults to `.anyError()` if `nil`, meaning any error is expected.
+    /// - Parameter file: The file where a verification failure is reported.
+    /// - Parameter line: The line where a verification failure is reported.
+    func `throws`(
+        _ errorMatcher: ArgMatcher<any Error>? = nil,
+        fileID: StaticString = #fileID,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) {
+        do {
+            try doesThrow(errorMatcher)
+        } catch {
+            SourceLocation(fileID: fileID, filePath: file, line: line, column: column).report(error)
+        }
+    }
+}
+
+public extension Assert where Eff: AsyncTypedThrowingEffect {
+    /// Asserts asynchronously that the mocked method threw an error.
+    ///
+    /// See the synchronous overload for why the matcher is not narrowed.
+    ///
+    /// - Parameter errorMatcher: An `ArgMatcher<any Error>` to specify the expected error.
+    ///   Defaults to `.anyError()` if `nil`, meaning any error is expected.
+    /// - Parameter file: The file where a verification failure is reported.
+    /// - Parameter line: The line where a verification failure is reported.
+    func `throws`(
+        _ errorMatcher: ArgMatcher<any Error>? = nil,
+        fileID: StaticString = #fileID,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) async {
+        do {
+            try await doesThrow(errorMatcher)
+        } catch {
+            SourceLocation(fileID: fileID, filePath: file, line: line, column: column).report(error)
+        }
+    }
+}
+
 private func withUntilTimeout<each Input, Eff: Effect>(
     interaction: Interaction<repeat each Input, Eff, some Any>,
     timeout: Duration,

--- a/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
+++ b/Tests/SwiftMockingMacrosTests/FunctionSignatureTests.swift
@@ -92,6 +92,128 @@ final class FunctionSignatureTests: MacroTestCase {
         }
     }
 
+    func testSingleMethodTypedThrows() {
+        assertMacro {
+           """
+            @Mockable()
+            protocol PricingService {
+                func price(_ item: String) throws(PricingError) -> Int
+            }
+            """
+        } expansion: {
+            """
+            protocol PricingService {
+                func price(_ item: String) throws(PricingError) -> Int
+            }
+
+            #if DEBUG
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
+                func price(_ item: ArgMatcher<String>) -> Interaction<String, TypedThrows<PricingError>, Int> {
+                    Interaction(item, spy: super.price)
+                }
+
+                func price(_ item: String) throws(PricingError) -> Int {
+                    let typedSpy: Spy<String, TypedThrows<PricingError>, Int> = super.price
+                    return try adaptTypedThrowing(typedSpy, item)
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    func testSingleMethodAsyncTypedThrows() {
+        assertMacro {
+           """
+            @Mockable()
+            protocol PricingService {
+                func price(_ item: String) async throws(PricingError) -> Int
+            }
+            """
+        } expansion: {
+            """
+            protocol PricingService {
+                func price(_ item: String) async throws(PricingError) -> Int
+            }
+
+            #if DEBUG
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
+                func price(_ item: ArgMatcher<String>) -> Interaction<String, AsyncTypedThrows<PricingError>, Int> {
+                    Interaction(item, spy: super.price)
+                }
+
+                func price(_ item: String) async throws(PricingError) -> Int {
+                    let typedSpy: Spy<String, AsyncTypedThrows<PricingError>, Int> = super.price
+                    return try await adaptAsyncTypedThrowing(typedSpy, item)
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    /// `throws(any Error)` is the canonical desugaring of an untyped `throws`, so it
+    /// must produce the untyped `Throws` effect rather than `TypedThrows<any Error>`.
+    func testSingleMethodThrowsAnyErrorStaysUntyped() {
+        assertMacro {
+           """
+            @Mockable()
+            protocol PricingService {
+                func price(_ item: String) throws(any Error) -> Int
+            }
+            """
+        } expansion: {
+            """
+            protocol PricingService {
+                func price(_ item: String) throws(any Error) -> Int
+            }
+
+            #if DEBUG
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
+                func price(_ item: ArgMatcher<String>) -> Interaction<String, Throws, Int> {
+                    Interaction(item, spy: super.price)
+                }
+
+                func price(_ item: String) throws(any Error) -> Int {
+                    return try adaptThrowing(super.price, item)
+                }
+            }
+            #endif
+            """
+        }
+    }
+
+    /// `throws(Never)` cannot throw, so callers invoke it without `try` and the
+    /// generated conformance must not emit one.
+    func testSingleMethodThrowsNeverIsNonThrowing() {
+        assertMacro {
+           """
+            @Mockable()
+            protocol PricingService {
+                func price(_ item: String) throws(Never) -> Int
+            }
+            """
+        } expansion: {
+            """
+            protocol PricingService {
+                func price(_ item: String) throws(Never) -> Int
+            }
+
+            #if DEBUG
+            class MockPricingService: Mock, @unchecked Sendable, PricingService {
+                func price(_ item: ArgMatcher<String>) -> Interaction<String, None, Int> {
+                    Interaction(item, spy: super.price)
+                }
+
+                func price(_ item: String) throws(Never) -> Int {
+                    return adapt(super.price, item)
+                }
+            }
+            #endif
+            """
+        }
+    }
+
     func testSingleMethodAsync() {
         assertMacro {
            """

--- a/Tests/SwiftMockingTests/SpyTests.swift
+++ b/Tests/SwiftMockingTests/SpyTests.swift
@@ -179,6 +179,30 @@ final class SpyTests: XCTestCase {
         XCTAssert(spy.verifyThrows(.error(TestError.self)))
     }
 
+    /// A later non-matching error must not clear an earlier match: `verifyThrows`
+    /// asks whether *any* invocation threw a matching error.
+    func test_spy_verifyThrows_preservesEarlierMatch() throws {
+        let spy = Spy<String, Throws, Int>()
+        spy.when(calledWith: "first").thenThrow(TestError.example)
+        spy.when(calledWith: "second").thenThrow(AnotherError())
+
+        _ = try? spy("first")
+        _ = try? spy("second")
+
+        XCTAssert(spy.verifyThrows(.error(TestError.self)))
+    }
+
+    func test_spy_typedThrows_verifyThrows_preservesEarlierMatch() throws {
+        let spy = Spy<String, TypedThrows<TestError>, Int>()
+        spy.when(calledWith: "first").thenThrow(.example)
+        spy.when(calledWith: "second").thenThrow(.other)
+
+        _ = try? spy("first")
+        _ = try? spy("second")
+
+        XCTAssert(spy.verifyThrows(.error(TestError.self)))
+    }
+
     func test_spy_asyncTypedThrows_rethrowsAsDeclaredErrorType() async {
         let spy = Spy<String, AsyncTypedThrows<TestError>, Int>()
         spy.when(calledWith: .any).thenThrow(.other)

--- a/Tests/SwiftMockingTests/SpyTests.swift
+++ b/Tests/SwiftMockingTests/SpyTests.swift
@@ -139,6 +139,70 @@ final class SpyTests: XCTestCase {
         XCTAssert(spy.verifyThrows(.error(TestError.self)))
     }
 
+    func test_spy_typedThrows_recordsInvocations_andReturnsStubbedValue() throws {
+        let spy = Spy<String, TypedThrows<TestError>, Int>()
+        spy.when(calledWith: .any).thenReturn(10)
+
+        let result1 = try spy("hello")
+        let result2 = try spy("world")
+
+        XCTAssertEqual(result1, 10)
+        XCTAssertEqual(result2, 10)
+
+        XCTAssertEqual(spy.invocations.count, 2)
+        XCTAssertEqual(spy.invocations[0].arguments, "hello")
+        XCTAssertEqual(spy.invocations[1].arguments, "world")
+    }
+
+    func test_spy_typedThrows_rethrowsAsDeclaredErrorType() {
+        let spy = Spy<String, TypedThrows<TestError>, Int>()
+        spy.when(calledWith: .any).thenThrow(.example)
+
+        // `error` is already a `TestError`: the spy's effect names the only type
+        // it can throw, so the catch needs no `as?` and no default case.
+        do {
+            _ = try spy("something")
+            XCTFail("Expected spy to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.example)
+        }
+    }
+
+    func test_spy_typedThrows_verification() throws {
+        let spy = Spy<String, TypedThrows<TestError>, Int>()
+        spy.when(calledWith: .any).thenThrow(.example)
+        do {
+            _ = try spy("something")
+        } catch {
+
+        }
+        XCTAssert(spy.verifyThrows(.error(TestError.self)))
+    }
+
+    func test_spy_asyncTypedThrows_rethrowsAsDeclaredErrorType() async {
+        let spy = Spy<String, AsyncTypedThrows<TestError>, Int>()
+        spy.when(calledWith: .any).thenThrow(.other)
+
+        do {
+            _ = try await spy("something")
+            XCTFail("Expected spy to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.other)
+        }
+    }
+
+    func test_spy_asyncTypedThrows_verification() async {
+        let spy = Spy<String, AsyncTypedThrows<TestError>, Int>()
+        spy.when(calledWith: .any).thenThrow(.example)
+        do {
+            _ = try await spy("something")
+        } catch {
+
+        }
+        let didThrow = await spy.verifyThrows(.error(TestError.self))
+        XCTAssert(didThrow)
+    }
+
     func test_spy_async_recordsInvocations_andReturnsStubbedValue() async {
         let spy = Spy<String, Async, Int>()
         spy.when(calledWith: .any).thenReturn(10)

--- a/Tests/SwiftMockingTests/TypedThrowsTests.swift
+++ b/Tests/SwiftMockingTests/TypedThrowsTests.swift
@@ -11,6 +11,9 @@ import SwiftMockingTestSupport
 protocol TypedThrowingService {
     func load(_ id: Int) throws(TestError) -> String
     func fetch(_ id: Int) async throws(TestError) -> String
+    /// `@escaping` describes how the parameter is passed, not its type. The spy's
+    /// pack must drop the attribute — `Spy<@escaping () -> Void, ...>` does not parse.
+    func run(_ handler: @escaping @Sendable () -> Void) throws(TestError) -> Int
 }
 
 /// End-to-end coverage for typed-throws requirements (`throws(E)`).
@@ -85,6 +88,24 @@ final class TypedThrowsTests: MockingTestCase {
         try verify(mock.load(.any)).doesThrow(.error(TestError.self))
     }
 
+    func testTypedThrows_FluentThrowsVerification() {
+        let mock = MockTypedThrowingService()
+        when(mock.load(.any)).thenThrow(.example)
+
+        _ = try? mock.load(1)
+
+        verify(mock.load(.any)).throws()
+        verify(mock.load(.any)).throws(.error(TestError.self))
+    }
+
+    func testTypedThrows_EscapingClosureParameter() throws {
+        let mock = MockTypedThrowingService()
+        when(mock.run(.any)).thenReturn(1)
+
+        XCTAssertEqual(try mock.run({}), 1)
+        verify(mock.run(.any)).called(1)
+    }
+
     // MARK: Asynchronous
 
     func testAsyncTypedThrows_RethrowsStubbedErrorAsDeclaredType() async {
@@ -123,6 +144,16 @@ final class TypedThrowsTests: MockingTestCase {
         } catch {
             XCTAssertEqual(error, TestError.other)
         }
+    }
+
+    func testAsyncTypedThrows_FluentThrowsVerification() async {
+        let mock = MockTypedThrowingService()
+        when(mock.fetch(.any)).thenThrow(.example)
+
+        _ = try? await mock.fetch(1)
+
+        await verify(mock.fetch(.any)).throws()
+        await verify(mock.fetch(.any)).throws(.error(TestError.self))
     }
 
     func testAsyncTypedThrows_VerifyAndDoesThrow() async throws {

--- a/Tests/SwiftMockingTests/TypedThrowsTests.swift
+++ b/Tests/SwiftMockingTests/TypedThrowsTests.swift
@@ -1,0 +1,138 @@
+//
+//  TypedThrowsTests.swift
+//  swift-mocking
+//
+
+import XCTest
+@testable import SwiftMocking
+import SwiftMockingTestSupport
+
+@Mockable
+protocol TypedThrowingService {
+    func load(_ id: Int) throws(TestError) -> String
+    func fetch(_ id: Int) async throws(TestError) -> String
+}
+
+/// End-to-end coverage for typed-throws requirements (`throws(E)`).
+///
+/// A typed-throws requirement carries its declared error type into the spy as
+/// `TypedThrows<E>` / `AsyncTypedThrows<E>`, so the generated conformance keeps the
+/// requirement's `throws(E)` signature instead of widening to `any Error`. These tests
+/// pin the three consequences that matters to callers: the error survives the round
+/// trip, it arrives already typed as `E` (no `as?` needed at the catch site), and
+/// stubbing/verification behave as they do for untyped throws.
+final class TypedThrowsTests: MockingTestCase {
+    // MARK: Synchronous
+
+    func testTypedThrows_RethrowsStubbedErrorAsDeclaredType() {
+        let mock = MockTypedThrowingService()
+        when(mock.load(.any)).thenThrow(.example)
+
+        // The `catch` binds `TestError` directly: with typed throws the compiler
+        // knows no other error can reach it, so there is no `as?` and no default case.
+        do {
+            _ = try mock.load(1)
+            XCTFail("Expected load to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.example)
+        }
+    }
+
+    func testTypedThrows_ReturnsStubbedValue() throws {
+        let mock = MockTypedThrowingService()
+        when(mock.load(.any)).thenReturn("loaded")
+
+        XCTAssertEqual(try mock.load(1), "loaded")
+    }
+
+    func testTypedThrows_MatcherSelectsBetweenValueAndError() {
+        let mock = MockTypedThrowingService()
+        when(mock.load(.equal(1))).thenReturn("one")
+        when(mock.load(.equal(2))).thenThrow(.other)
+
+        XCTAssertEqual(try? mock.load(1), "one")
+        do {
+            _ = try mock.load(2)
+            XCTFail("Expected load(2) to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.other)
+        }
+    }
+
+    func testTypedThrows_ThrowingHandlerPropagatesDeclaredError() {
+        let mock = MockTypedThrowingService()
+        when(mock.load(.any)).thenReturn { (id: Int) throws(TestError) -> String in
+            if id < 0 { throw .other }
+            return "id-\(id)"
+        }
+
+        XCTAssertEqual(try? mock.load(3), "id-3")
+        do {
+            _ = try mock.load(-1)
+            XCTFail("Expected load(-1) to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.other)
+        }
+    }
+
+    func testTypedThrows_VerifyAndDoesThrow() throws {
+        let mock = MockTypedThrowingService()
+        when(mock.load(.any)).thenThrow(.example)
+
+        _ = try? mock.load(1)
+
+        verify(mock.load(.equal(1))).called(1)
+        try verify(mock.load(.any)).doesThrow(.error(TestError.self))
+    }
+
+    // MARK: Asynchronous
+
+    func testAsyncTypedThrows_RethrowsStubbedErrorAsDeclaredType() async {
+        let mock = MockTypedThrowingService()
+        when(mock.fetch(.any)).thenThrow(.example)
+
+        do {
+            _ = try await mock.fetch(1)
+            XCTFail("Expected fetch to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.example)
+        }
+    }
+
+    func testAsyncTypedThrows_ReturnsStubbedValue() async throws {
+        let mock = MockTypedThrowingService()
+        when(mock.fetch(.any)).thenReturn("fetched")
+
+        let value = try await mock.fetch(1)
+        XCTAssertEqual(value, "fetched")
+    }
+
+    func testAsyncTypedThrows_AsyncThrowingHandlerPropagatesDeclaredError() async {
+        let mock = MockTypedThrowingService()
+        when(mock.fetch(.any)).thenReturn { (id: Int) async throws(TestError) -> String in
+            if id < 0 { throw .other }
+            return "id-\(id)"
+        }
+
+        let value = try? await mock.fetch(3)
+        XCTAssertEqual(value, "id-3")
+
+        do {
+            _ = try await mock.fetch(-1)
+            XCTFail("Expected fetch(-1) to throw")
+        } catch {
+            XCTAssertEqual(error, TestError.other)
+        }
+    }
+
+    func testAsyncTypedThrows_VerifyAndDoesThrow() async throws {
+        let mock = MockTypedThrowingService()
+        when(mock.fetch(.any)).thenThrow(.example)
+
+        _ = try? await mock.fetch(1)
+
+        verify(mock.fetch(.equal(1))).called(1)
+        try await verify(mock.fetch(.any)).doesThrow(.error(TestError.self))
+    }
+}
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,6 +5,7 @@ the library, the [interactive tutorials](https://danielcardonarojas.github.io/sw
 teach the same material in order, with runnable code at each step.
 
 - [Argument Matching](#argument-matching)
+- [Typed Throws](#typed-throws)
 - [Properties and Subscripts](#properties-and-subscripts)
 - [Dynamic Stubbing](#dynamic-stubbing)
 - [Logging Invocations](#logging-invocations)
@@ -142,6 +143,71 @@ verifyInOrder([
     pricingMock.price("banana")
 ])
 ```
+
+## Typed Throws
+
+Requirements declared with [typed throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md) keep their error type through the mock. The generated conformance stays `throws(E)` rather than widening to `any Error`, so callers catch the concrete type and the compiler checks your stubs against it.
+
+```swift
+@Mockable
+protocol PricingService {
+    func price(_ item: String) throws(PricingError) -> Int
+}
+```
+
+Stubbing and verification work as they do for untyped `throws`, with one addition: `thenThrow` accepts only the declared error type.
+
+```swift
+let mock = MockPricingService()
+when(mock.price(.any)).thenThrow(.outOfStock)
+
+do {
+    _ = try mock.price("apple")
+} catch {
+    // `error` is already a `PricingError` — no `as?`, no default case.
+    XCTAssertEqual(error, .outOfStock)
+}
+
+verify(mock.price(.any)).called(1)
+```
+
+Stubbing an error the requirement cannot throw does not compile:
+
+```swift
+when(mock.price(.any)).thenThrow(NetworkError.offline)
+// ❌ error: cannot convert value of type 'NetworkError' to expected
+//           argument type 'TypedThrows<PricingError>.Failure'
+//           (aka 'PricingError')
+```
+
+Dynamic stubbing carries the same constraint — the handler is typed `throws(E)`:
+
+```swift
+when(mock.price(.any)).thenReturn { (item: String) throws(PricingError) -> Int in
+    guard item != "unobtainium" else { throw .outOfStock }
+    return item.count
+}
+```
+
+`async throws(E)` is supported the same way, producing an `AsyncTypedThrows<E>` spy:
+
+```swift
+when(mock.fetchPrice(.any)).thenThrow(.outOfStock)
+_ = try? await mock.fetchPrice("apple")
+try await verify(mock.fetchPrice(.any)).doesThrow(.error(PricingError.self))
+```
+
+Two spellings deliberately keep the untyped behaviour, since they mean the same thing as their untyped forms:
+
+| Declaration | Effect | Why |
+| --- | --- | --- |
+| `throws(any Error)` | `Throws` | The canonical desugaring of untyped `throws`. |
+| `throws(Never)` | `None` | Cannot throw, so callers need no `try`. |
+
+> [!NOTE]
+> An unstubbed call to a typed-throws method traps rather than throwing. The signature admits only `E`, leaving no way to surface a `MockingError` — the same way non-throwing mocks already report an unstubbed call. Give the method a stub, or a [default value](#default-values-for-unstubbed-methods).
+
+---
 
 ## Properties and Subscripts
 

--- a/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
+++ b/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
@@ -659,3 +659,9 @@ extension Assert where Eff == Throws {
 extension Assert where Eff == AsyncThrows {
   public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) async
 }
+extension Assert where Eff : SyncTypedThrowingEffect {
+  public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column)
+}
+extension Assert where Eff : AsyncTypedThrowingEffect {
+  public func `throws`(_ errorMatcher: ArgMatcher<any Error>? = nil, fileID: StaticString = #fileID, file: StaticString = #filePath, line: UInt = #line, column: UInt = #column) async
+}

--- a/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
+++ b/skills/swift-mocking/references/interface/SwiftMocking.swiftinterface
@@ -18,6 +18,12 @@ extension Action where Eff == None {
 extension Action where Eff == Throws {
   final public func `do`(_ handler: @escaping @Sendable (repeat each I) throws -> Void)
 }
+extension Action where Eff : SyncTypedThrowingEffect {
+  final public func `do`(_ handler: @escaping @Sendable (repeat each I) throws(Eff.Failure) -> Void)
+}
+extension Action where Eff : AsyncTypedThrowingEffect {
+  final public func `do`(_ handler: @escaping @Sendable (repeat each I) async throws(Eff.Failure) -> Void)
+}
 extension Action where Eff == Async {
   final public func `do`(_ handler: @escaping @Sendable (repeat each I) async -> Void)
 }
@@ -70,7 +76,8 @@ extension ArgMatcher where Argument : Error {
   public static func error<E>(_ type: E.Type) -> ArgMatcher<Argument> where E : Error
 }
 extension ArgMatcher {
-  public static func any<Property>(where keyPath: KeyPath<Argument, Property>, _ value: Property) -> ArgMatcher<Argument> where Argument : Sendable, Property : Equatable, Property : Sendable
+  public static func any<Property>(where keyPath: KeyPath<Argument, Property>, equals value: Property) -> ArgMatcher<Argument> where Argument : Sendable, Property : Equatable, Property : Sendable
+  @_disfavoredOverload public static func any<Property>(where keyPath: KeyPath<Argument, Property>, _ value: Property) -> ArgMatcher<Argument> where Argument : Sendable, Property : Equatable, Property : Sendable
 }
 extension ArgMatcher : ExpressibleByIntegerLiteral where Argument == Int {
   public init(integerLiteral value: IntegerLiteralType)
@@ -153,6 +160,18 @@ extension Arrange where Eff == Throws {
   final public func thenReturn(_ handler: @escaping @Sendable (repeat each I) throws -> Output) where repeat each I : Sendable
   final public func `do`(_ handler: @escaping @Sendable (repeat each I) throws -> Void)
 }
+extension Arrange where Eff : SyncTypedThrowingEffect {
+  final public func thenReturn(_ output: Output) where Output : Sendable
+  final public func thenThrow(_ error: Eff.Failure)
+  final public func thenReturn(_ handler: @escaping @Sendable (repeat each I) throws(Eff.Failure) -> Output) where repeat each I : Sendable
+  final public func `do`(_ handler: @escaping @Sendable (repeat each I) throws(Eff.Failure) -> Void)
+}
+extension Arrange where Eff : AsyncTypedThrowingEffect {
+  final public func thenReturn(_ output: Output) where Output : Sendable
+  final public func thenThrow(_ error: Eff.Failure)
+  final public func thenReturn(_ handler: @escaping @Sendable (repeat each I) async throws(Eff.Failure) -> Output) where repeat each I : Sendable
+  final public func `do`(_ handler: @escaping @Sendable (repeat each I) async throws(Eff.Failure) -> Void)
+}
 extension Arrange where Eff == Async {
   final public func thenReturn(_ output: Output) where Output : Sendable
   final public func thenReturn(_ handler: @escaping @Sendable (repeat each I) -> Output)
@@ -172,6 +191,12 @@ public class Assert<each Input, Eff, Output> where Eff : Effect {
 }
 extension Assert where Eff == Throws {
   public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) throws
+}
+extension Assert where Eff : SyncTypedThrowingEffect {
+  public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) throws
+}
+extension Assert where Eff : AsyncTypedThrowingEffect {
+  public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) async throws
 }
 extension Assert where Eff == AsyncThrows {
   public func doesThrow(_ errorMatcher: ArgMatcher<any Error>? = nil) async throws
@@ -240,9 +265,26 @@ public protocol Effect : Sendable {
 }
 public enum Throws : Effect, Sendable {
 }
+public enum TypedThrows<E> : Effect, Sendable where E : Error {
+}
+public protocol TypedThrowingEffect : Effect {
+  associatedtype Failure : Error
+}
+public protocol SyncTypedThrowingEffect : TypedThrowingEffect {
+}
+public protocol AsyncTypedThrowingEffect : TypedThrowingEffect {
+}
+extension TypedThrows : SyncTypedThrowingEffect {
+  public typealias Failure = E
+}
 public enum Async : Effect, Sendable {
 }
 public enum AsyncThrows : Effect, Sendable {
+}
+public enum AsyncTypedThrows<E> : Effect, Sendable where E : Error {
+}
+extension AsyncTypedThrows : AsyncTypedThrowingEffect {
+  public typealias Failure = E
 }
 public enum None : Effect, Sendable {
 }
@@ -341,6 +383,10 @@ extension Mock {
     }
   public static func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, Throws, O>, _ input: repeat each I) throws -> O
   public func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, Throws, O>, _ input: repeat each I) throws -> O
+  public static func adaptTypedThrowing<each I, E, O>(_ spy: Spy<repeat each I, TypedThrows<E>, O>, _ input: repeat each I) throws(E) -> O where E : Error
+  public func adaptTypedThrowing<each I, E, O>(_ spy: Spy<repeat each I, TypedThrows<E>, O>, _ input: repeat each I) throws(E) -> O where E : Error
+  public static func adaptAsyncTypedThrowing<each I, E, O>(_ spy: Spy<repeat each I, AsyncTypedThrows<E>, O>, _ input: repeat each I) async throws(E) -> O where E : Error
+  public func adaptAsyncTypedThrowing<each I, E, O>(_ spy: Spy<repeat each I, AsyncTypedThrows<E>, O>, _ input: repeat each I) async throws(E) -> O where E : Error
   public static func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, AsyncThrows, O>, _ input: repeat each I) async throws -> O
   public func adaptThrowing<each I, O>(_ spy: Spy<repeat each I, AsyncThrows, O>, _ input: repeat each I) async throws -> O
 }
@@ -476,6 +522,20 @@ extension Spy where Effects == Throws {
   public func verifyThrows(_ errorMatcher: ArgMatcher<any Error>) -> Bool
   public func verifyThrows() -> Bool
 }
+extension Spy where Effects : SyncTypedThrowingEffect {
+  @discardableResult
+  public func callAsFunction(_ input: repeat each Input) throws(Effects.Failure) -> Output
+  public func asFunction() -> @Sendable (repeat each Input) throws(Effects.Failure) -> Output
+  public func verifyThrows(_ errorMatcher: ArgMatcher<any Error>) -> Bool
+  public func verifyThrows() -> Bool
+}
+extension Spy where Effects : AsyncTypedThrowingEffect {
+  @discardableResult
+  public func callAsFunction(_ input: repeat each Input) async throws(Effects.Failure) -> Output
+  public func asFunction() -> @Sendable (repeat each Input) async throws(Effects.Failure) -> Output
+  public func verifyThrows(_ errorMatcher: ArgMatcher<any Error>) async -> Bool
+  public func verifyThrows() async -> Bool
+}
 extension Spy where Effects == None {
   @discardableResult
   @inline(__always) public func callAsFunction(_ input: repeat each Input) -> Output {
@@ -540,6 +600,19 @@ extension Stub where Effects == Throws {
   public func thenReturn(_ handler: @escaping @Sendable (repeat each I) -> O)
   public func thenThrow<E>(_ error: E) where E : Error
   public func thenReturn(_ handler: @escaping @Sendable (repeat each I) throws -> O) where repeat each I : Sendable
+}
+extension Stub where Effects : SyncTypedThrowingEffect {
+  public func thenReturn(_ output: O) where O : Sendable
+  public func thenReturn(_ handler: @escaping @Sendable (repeat each I) -> O)
+  public func thenThrow(_ error: Effects.Failure)
+  public func thenReturn(_ handler: @escaping @Sendable (repeat each I) throws(Effects.Failure) -> O) where repeat each I : Sendable
+}
+extension Stub where Effects : AsyncTypedThrowingEffect {
+  public func thenReturn(_ output: O) where O : Sendable
+  public func thenReturn(_ handler: @escaping @Sendable (repeat each I) -> O)
+  public func thenThrow(_ error: Effects.Failure)
+  public func thenReturn(_ handler: @escaping @Sendable (repeat each I) async -> O) where repeat each I : Sendable
+  public func thenReturn(_ handler: @escaping @Sendable (repeat each I) async throws(Effects.Failure) -> O) where repeat each I : Sendable
 }
 extension Stub where Effects == Async {
   public func thenReturn(_ output: O) where O : Sendable


### PR DESCRIPTION
Adds support for [typed throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md) (`throws(E)`), so a requirement's declared error type survives into the mock instead of being erased to `any Error`.

```swift
@Mockable
protocol PricingService {
    func price(_ item: String) throws(PricingError) -> Int
}

when(mock.price(.any)).thenThrow(.outOfStock)

do {
    _ = try mock.price("apple")
} catch {
    // `error` is already a `PricingError` — no `as?`, no default case.
    XCTAssertEqual(error, .outOfStock)
}
```

Stubbing an error the requirement cannot throw is now a compile error rather than a failure found at call time.

## How it works

`TypedThrows<E>` and `AsyncTypedThrows<E>` carry the error type as a phantom parameter, mirroring the existing `Throws`/`AsyncThrows` pair. A `TypedThrowingEffect` protocol projects it back out as an associated `Failure`, so extensions constrain on the effect and still name the concrete error.

`Return` keeps storing failures as `any Error`. A `Return` can also hold a `MockingError` for an unstubbed call, which by construction is not an `E`, so a typed failure type would not be representable. Narrowing happens once, at the call boundary in `Spy.narrow(_:)`.

## Behaviour worth reviewing

- **Unstubbed calls trap.** The signature admits only `E`, leaving no way to surface a `MockingError`. This matches how non-throwing spies (`None`, `Async`) already report the same mistake.
- **`throws(any Error)` stays untyped** — it is the canonical desugaring of `throws`, so generating `TypedThrows<any Error>` would be pointless.
- **`throws(Never)` becomes non-throwing** — callers invoke it without `try`, so emitting one would not compile.

## Two inference constraints shaped the generated code

Both were found by compiling, and are documented in the source:

1. The typed adapters cannot be `adaptThrowing` overloads. The spy comes from `Mock`'s generic `@dynamicMemberLookup` subscript, so its effect is inferred *from* the adapter parameter; sharing a name let the solver pick the untyped overload. Hence `adaptTypedThrowing` / `adaptAsyncTypedThrowing`.
2. Generated bodies bind the spy to an explicitly typed local. `E` appears only in `throws(E)` and in the spy's effect, so with nothing spelled both stayed open (`generic parameter 'E' could not be inferred`). This is the same anchoring the settable-subscript interactions already use.

```swift
func price(_ item: String) throws(PricingError) -> Int {
    let typedSpy: Spy<String, TypedThrows<PricingError>, Int> = super.price
    return try adaptTypedThrowing(typedSpy, item)
}
```

## Testing

274 tests pass in the main package, 19 in Examples.

- Macro expansion tests pin all four spellings, including the two that must *not* produce a typed effect.
- `TypedThrowsTests` drives a generated mock end to end; `SpyTests` covers a directly constructed `Spy`, so a runtime regression is distinguishable from a codegen one.
- The compile-time rejection of a wrong error type was verified against the compiler.

## Docs

Kept off the front page: `GENERATED_CODE_EXAMPLES.md` gains the two expansions, `docs/usage.md` gains a Typed Throws section. The README keeps only the feature-table entry and a pointer. Every documented sample was compiled and run.

`skills/swift-mocking/references/interface/SwiftMocking.swiftinterface` was regenerated; it also picks up `.any(where:equals:)` from c4960bb, which had left it stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for synchronous and asynchronous typed throws, preserving declared error types in generated mocks and spies.
  * Added typed-throwing stubbing, actions, handlers, assertions, verification, and adapters.
  * Added support for typed error propagation without manual error casting.
  * Clarified handling of untyped throws and non-throwing requirements.

* **Documentation**
  * Added usage guidance and generated examples for typed throws, including async behavior and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->